### PR TITLE
chore: remplate plugin not supporting ESM with new one

### DIFF
--- a/.changeset/fruity-pigs-cover.md
+++ b/.changeset/fruity-pigs-cover.md
@@ -1,0 +1,19 @@
+---
+"scaffolder-toolkit": patch
+---
+
+### Summary of Changes
+
+This release addresses a critical build issue by migrating the project's build system from `esbuild` to **Rollup**. This change resolves the `Dynamic require` bug for CommonJS dependencies, ensuring the CLI builds and runs correctly in a Node.js environment.
+
+---
+
+### Key Changes:
+
+- **Build Pipeline Migration:** Replaced the `esbuild` build process with a **Rollup** configuration to correctly handle CJS dependencies.
+- **CommonJS Compatibility:** Integrated and configured `@rollup/plugin-commonjs` to resolve `require` calls in third-party libraries.
+- **External Dependencies:** Explicitly marked Node.js built-in modules (`fs`, `path`, etc.) and project dependencies as `external` in the Rollup config, preventing them from being bundled. This is a best practice for Node.js CLI tools.
+- **JSON Handling:** Added `@rollup/plugin-json` to the build process to correctly import `.json` files from dependencies.
+- **Build Artifacts:** Adjusted the configuration to prevent the generation of sourcemap files.
+- **Test Suite Reliability:** Updated integration tests to be more resilient to inconsistent CLI output, using regular expressions and whitespace normalization to ensure reliable assertions.
+- **Documentation:** Updated the `README.md` to reflect the new global installation advice and correct minor Markdown formatting issues.

--- a/bun.lock
+++ b/bun.lock
@@ -2,7 +2,7 @@
   "lockfileVersion": 1,
   "workspaces": {
     "": {
-      "name": "devkit",
+      "name": "dev-tools",
       "devDependencies": {
         "@changesets/cli": "^2.29.5",
         "@commitlint/cli": "^19.8.1",
@@ -17,27 +17,29 @@
     },
     "packages/devkit": {
       "name": "scaffolder-toolkit",
-      "version": "1.0.2",
+      "version": "1.0.4",
       "bin": {
-        "devkit": "./dist/main.js",
-        "dk": "./dist/main.js",
+        "devkit": "./dist/bundle.js",
+        "dk": "./dist/bundle.js",
       },
       "dependencies": {
+        "@inquirer/prompts": "^7.8.4",
         "chalk": "^5.5.0",
         "commander": "^14.0.0",
         "deepmerge": "^4.3.1",
         "execa": "^9.6.0",
-        "fs-extra": "^11.3.1",
         "ora": "^8.2.0",
         "os-locale": "^6.0.2",
-        "prompts": "^2.4.2",
       },
       "devDependencies": {
-        "@types/fs-extra": "^11.0.4",
-        "@types/prompts": "^2.4.9",
+        "@rollup/plugin-commonjs": "^28.0.6",
+        "@rollup/plugin-json": "^6.1.0",
+        "@rollup/plugin-node-resolve": "^16.0.1",
+        "@rollup/plugin-typescript": "^12.1.4",
+        "@types/inquirer": "^9.0.9",
         "@vitest/coverage-v8": "^3.2.4",
         "cpx": "^1.5.0",
-        "esbuild": "^0.25.9",
+        "rollup": "^4.50.1",
         "typescript": "^5.0.0",
         "vitest": "^3.2.4",
       },
@@ -52,11 +54,11 @@
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.27.1", "", {}, "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow=="],
 
-    "@babel/parser": ["@babel/parser@7.28.3", "", { "dependencies": { "@babel/types": "^7.28.2" }, "bin": "./bin/babel-parser.js" }, "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA=="],
+    "@babel/parser": ["@babel/parser@7.28.4", "", { "dependencies": { "@babel/types": "^7.28.4" }, "bin": "./bin/babel-parser.js" }, "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg=="],
 
-    "@babel/runtime": ["@babel/runtime@7.28.3", "", {}, "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA=="],
+    "@babel/runtime": ["@babel/runtime@7.28.4", "", {}, "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="],
 
-    "@babel/types": ["@babel/types@7.28.2", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ=="],
+    "@babel/types": ["@babel/types@7.28.4", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q=="],
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
@@ -180,7 +182,35 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.9", "", { "os": "win32", "cpu": "x64" }, "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ=="],
 
+    "@inquirer/checkbox": ["@inquirer/checkbox@4.2.2", "", { "dependencies": { "@inquirer/core": "^10.2.0", "@inquirer/figures": "^1.0.13", "@inquirer/type": "^3.0.8", "ansi-escapes": "^4.3.2", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-E+KExNurKcUJJdxmjglTl141EwxWyAHplvsYJQgSwXf8qiNWkTxTuCCqmhFEmbIXd4zLaGMfQFJ6WrZ7fSeV3g=="],
+
+    "@inquirer/confirm": ["@inquirer/confirm@5.1.16", "", { "dependencies": { "@inquirer/core": "^10.2.0", "@inquirer/type": "^3.0.8" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-j1a5VstaK5KQy8Mu8cHmuQvN1Zc62TbLhjJxwHvKPPKEoowSF6h/0UdOpA9DNdWZ+9Inq73+puRq1df6OJ8Sag=="],
+
+    "@inquirer/core": ["@inquirer/core@10.2.0", "", { "dependencies": { "@inquirer/figures": "^1.0.13", "@inquirer/type": "^3.0.8", "ansi-escapes": "^4.3.2", "cli-width": "^4.1.0", "mute-stream": "^2.0.0", "signal-exit": "^4.1.0", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-NyDSjPqhSvpZEMZrLCYUquWNl+XC/moEcVFqS55IEYIYsY0a1cUCevSqk7ctOlnm/RaSBU5psFryNlxcmGrjaA=="],
+
+    "@inquirer/editor": ["@inquirer/editor@4.2.18", "", { "dependencies": { "@inquirer/core": "^10.2.0", "@inquirer/external-editor": "^1.0.1", "@inquirer/type": "^3.0.8" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-yeQN3AXjCm7+Hmq5L6Dm2wEDeBRdAZuyZ4I7tWSSanbxDzqM0KqzoDbKM7p4ebllAYdoQuPJS6N71/3L281i6w=="],
+
+    "@inquirer/expand": ["@inquirer/expand@4.0.18", "", { "dependencies": { "@inquirer/core": "^10.2.0", "@inquirer/type": "^3.0.8", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-xUjteYtavH7HwDMzq4Cn2X4Qsh5NozoDHCJTdoXg9HfZ4w3R6mxV1B9tL7DGJX2eq/zqtsFjhm0/RJIMGlh3ag=="],
+
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.1", "", { "dependencies": { "chardet": "^2.1.0", "iconv-lite": "^0.6.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-Oau4yL24d2B5IL4ma4UpbQigkVhzPDXLoqy1ggK4gnHg/stmkffJE4oOXHXF3uz0UEpywG68KcyXsyYpA1Re/Q=="],
+
+    "@inquirer/figures": ["@inquirer/figures@1.0.13", "", {}, "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw=="],
+
+    "@inquirer/input": ["@inquirer/input@4.2.2", "", { "dependencies": { "@inquirer/core": "^10.2.0", "@inquirer/type": "^3.0.8" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-hqOvBZj/MhQCpHUuD3MVq18SSoDNHy7wEnQ8mtvs71K8OPZVXJinOzcvQna33dNYLYE4LkA9BlhAhK6MJcsVbw=="],
+
+    "@inquirer/number": ["@inquirer/number@3.0.18", "", { "dependencies": { "@inquirer/core": "^10.2.0", "@inquirer/type": "^3.0.8" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-7exgBm52WXZRczsydCVftozFTrrwbG5ySE0GqUd2zLNSBXyIucs2Wnm7ZKLe/aUu6NUg9dg7Q80QIHCdZJiY4A=="],
+
+    "@inquirer/password": ["@inquirer/password@4.0.18", "", { "dependencies": { "@inquirer/core": "^10.2.0", "@inquirer/type": "^3.0.8", "ansi-escapes": "^4.3.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-zXvzAGxPQTNk/SbT3carAD4Iqi6A2JS2qtcqQjsL22uvD+JfQzUrDEtPjLL7PLn8zlSNyPdY02IiQjzoL9TStA=="],
+
+    "@inquirer/prompts": ["@inquirer/prompts@7.8.4", "", { "dependencies": { "@inquirer/checkbox": "^4.2.2", "@inquirer/confirm": "^5.1.16", "@inquirer/editor": "^4.2.18", "@inquirer/expand": "^4.0.18", "@inquirer/input": "^4.2.2", "@inquirer/number": "^3.0.18", "@inquirer/password": "^4.0.18", "@inquirer/rawlist": "^4.1.6", "@inquirer/search": "^3.1.1", "@inquirer/select": "^4.3.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-MuxVZ1en1g5oGamXV3DWP89GEkdD54alcfhHd7InUW5BifAdKQEK9SLFa/5hlWbvuhMPlobF0WAx7Okq988Jxg=="],
+
+    "@inquirer/rawlist": ["@inquirer/rawlist@4.1.6", "", { "dependencies": { "@inquirer/core": "^10.2.0", "@inquirer/type": "^3.0.8", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-KOZqa3QNr3f0pMnufzL7K+nweFFCCBs6LCXZzXDrVGTyssjLeudn5ySktZYv1XiSqobyHRYYK0c6QsOxJEhXKA=="],
+
+    "@inquirer/search": ["@inquirer/search@3.1.1", "", { "dependencies": { "@inquirer/core": "^10.2.0", "@inquirer/figures": "^1.0.13", "@inquirer/type": "^3.0.8", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-TkMUY+A2p2EYVY3GCTItYGvqT6LiLzHBnqsU1rJbrpXUijFfM6zvUx0R4civofVwFCmJZcKqOVwwWAjplKkhxA=="],
+
+    "@inquirer/select": ["@inquirer/select@4.3.2", "", { "dependencies": { "@inquirer/core": "^10.2.0", "@inquirer/figures": "^1.0.13", "@inquirer/type": "^3.0.8", "ansi-escapes": "^4.3.2", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-nwous24r31M+WyDEHV+qckXkepvihxhnyIaod2MG7eCE6G0Zm/HUF6jgN8GXgf4U7AU6SLseKdanY195cwvU6w=="],
+
+    "@inquirer/type": ["@inquirer/type@3.0.8", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw=="],
 
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
@@ -204,81 +234,81 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@0.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-qL0zqIYdYrXl6ghTIHnhJkvyYy1eKz0P8YIEp59MjY3/zNiyk/gtyp8LkwZdqb9ezbcX9UDQhSuSO1wURJsq8g=="],
+    "@oxlint/darwin-arm64": ["@oxlint/darwin-arm64@1.14.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-rcTw0QWeOc6IeVp+Up7WtcwdS9l4j7TOq4tihF0Ud/fl+VUVdvDCPuZ9QTnLXJhwMXiyQRWdxRyI6XBwf80ncQ=="],
 
-    "@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@0.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-c3nSjqmDSKzemChAEUv/zy2e9cwgkkO/7rz4Y447+8pSbeZNHi3RrNpVHdrKL/Qep4pt6nFZE+6PoczZxHNQjg=="],
+    "@oxlint/darwin-x64": ["@oxlint/darwin-x64@1.14.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-TWFSEmyl2/DN4HoXNwQl0y/y3EXFJDctfv5MiDtVOV1GJKX80cGSIxMxXb08Q3CCWqteqEijmfSMo5TG8X1H/A=="],
 
-    "@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@0.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-P2BA54c/Ej5AGkChH1/7zMd6PwZfa+jnw8juB/JWops+BX+lbhbbBHz0cYduDBgWYjRo4e3OVJOTskqcpuMfNw=="],
+    "@oxlint/linux-arm64-gnu": ["@oxlint/linux-arm64-gnu@1.14.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-N1FqdKfwhVWPpMElv8qlGqdEefTbDYaRVhdGWOjs/2f7FESa5vX0cvA7ToqzkoXyXZI5DqByWiPML33njK30Kg=="],
 
-    "@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@0.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-hbgLpnDNicPrbHOAQ9nNfLOSrUrdWANP/umR7P/cwCc1sv66eEs7bm4G3mrhRU8aXFBJmbhdNqiDSUkYYvHWJQ=="],
+    "@oxlint/linux-arm64-musl": ["@oxlint/linux-arm64-musl@1.14.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-v/BPuiateLBb7Gz1STb69EWjkgKdlPQ1NM56z+QQur21ly2hiMkBX2n0zEhqfu9PQVRUizu6AlsYuzcPY/zsIQ=="],
 
-    "@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@0.0.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-ozKEppmwZhC5LMedClBEat6cXgBGUvxGOgsKK2ZZNE6zSScX7QbvJAOt3nWMGs8GQshHy/6ndMB33+uRloglQA=="],
+    "@oxlint/linux-x64-gnu": ["@oxlint/linux-x64-gnu@1.14.0", "", { "os": "linux", "cpu": "x64" }, "sha512-gUTp8KIrSYt97dn+tRRC3LKnH4xlHKCwrPwiDcGmLbCxojuN9/H5mnIhPKEfwNuZNdoKGS/ABuq3neVyvRCRtQ=="],
 
-    "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@0.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-gLfx+qogW21QcaRKFg6ARgra7tSPqyn+Ems3FgTUyxV4OpJYn7KsQroygxOWElqv6JUobtvHBrxdB6YhlvERbQ=="],
+    "@oxlint/linux-x64-musl": ["@oxlint/linux-x64-musl@1.14.0", "", { "os": "linux", "cpu": "x64" }, "sha512-DpN6cW2HPjYXeENG0JBbmubO8LtfKt6qJqEMBw9gUevbyBaX+k+Jn7sYgh6S23wGOkzmTNphBsf/7ulj4nIVYA=="],
 
-    "@oxlint/darwin-arm64": ["@oxlint/darwin-arm64@1.12.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Pv+Ho1uq2ny8g2P6JgQpaIUF1FHPL32DfOlZhKqmzDT3PydtFvZp/7zNyJE3BIXeTOOOG1Eg12hjZHMLsWxyNw=="],
+    "@oxlint/win32-arm64": ["@oxlint/win32-arm64@1.14.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-oXxJksnUTUMgJ0NvjKS1mrCXAy1ttPgIVacRSlxQ+1XHy+aJDMM7I8fsCtoKoEcTIpPaD98eqUqlLYs0H2MGjA=="],
 
-    "@oxlint/darwin-x64": ["@oxlint/darwin-x64@1.12.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-kNXPH/7jXjX4pawrEWXQHOasOdOsrYKhskA1qYwLYcv/COVSoxOSElkQtQa+KxN5zzt3F02kBdWDndLpgJLbLQ=="],
-
-    "@oxlint/linux-arm64-gnu": ["@oxlint/linux-arm64-gnu@1.12.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-U7NETs02K55ZyDlgdhx4lWeFYbkUKcL+YcG+Ak70EyEt/BKIIVt4B84VdV1JzC71FErUipDYAwPJmxMREXr4Sg=="],
-
-    "@oxlint/linux-arm64-musl": ["@oxlint/linux-arm64-musl@1.12.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-e4Pb2eZu3V2BsiX4t4gyv9iJ8+KRT6bkoWM5uC9BLX7edsVchwLwL6LB2vPYusYdPPrxdjlFCg6ni+9wlw7FbQ=="],
-
-    "@oxlint/linux-x64-gnu": ["@oxlint/linux-x64-gnu@1.12.0", "", { "os": "linux", "cpu": "x64" }, "sha512-qJK98Dj/z7Nbm0xoz0nCCMFGy0W/kLewPzOK5QENxuUoQQ6ymt7/75rXOuTwAZJ6JFTarqfSuMAA0pka6Tmytw=="],
-
-    "@oxlint/linux-x64-musl": ["@oxlint/linux-x64-musl@1.12.0", "", { "os": "linux", "cpu": "x64" }, "sha512-jNeltpHc1eonSev/bWKipJ7FI6+Rc7EXh6Y7E0pm8e95sc1klFA29FFVs3FjMA6CCa+SRT0u0nnNTTAtf2QOiQ=="],
-
-    "@oxlint/win32-arm64": ["@oxlint/win32-arm64@1.12.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-T3fpNZJ3Q9YGgJTKc1YyvGoomSXnrV5mREz0QACE06zUzfS8EWyaYc/GN17FhHvQ4uQk/1xLgnM6FPsuLMeRhw=="],
-
-    "@oxlint/win32-x64": ["@oxlint/win32-x64@1.12.0", "", { "os": "win32", "cpu": "x64" }, "sha512-2eC4XQ1SMM2z7bCDG+Ifrn5GrvP6fkL0FGi4ZwDCrx6fwb1byFrXgSUNIPiqiiqBBrFRMKlXzU9zD6IjuFlUOg=="],
+    "@oxlint/win32-x64": ["@oxlint/win32-x64@1.14.0", "", { "os": "win32", "cpu": "x64" }, "sha512-iRYy2rhTQKFztyx0jtNMRBnFpzsRwFdjWQ7sKKzJpmbijA3Tw3DCqlGT7QRgoVRF0+X/ccNGvvsrgMohPVfLeQ=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
-    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.48.1", "", { "os": "android", "cpu": "arm" }, "sha512-rGmb8qoG/zdmKoYELCBwu7vt+9HxZ7Koos3pD0+sH5fR3u3Wb/jGcpnqxcnWsPEKDUyzeLSqksN8LJtgXjqBYw=="],
+    "@rollup/plugin-commonjs": ["@rollup/plugin-commonjs@28.0.6", "", { "dependencies": { "@rollup/pluginutils": "^5.0.1", "commondir": "^1.0.1", "estree-walker": "^2.0.2", "fdir": "^6.2.0", "is-reference": "1.2.1", "magic-string": "^0.30.3", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^2.68.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-XSQB1K7FUU5QP+3lOQmVCE3I0FcbbNvmNT4VJSj93iUjayaARrTQeoRdiYQoftAJBLrR9t2agwAd3ekaTgHNlw=="],
 
-    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.48.1", "", { "os": "android", "cpu": "arm64" }, "sha512-4e9WtTxrk3gu1DFE+imNJr4WsL13nWbD/Y6wQcyku5qadlKHY3OQ3LJ/INrrjngv2BJIHnIzbqMk1GTAC2P8yQ=="],
+    "@rollup/plugin-json": ["@rollup/plugin-json@6.1.0", "", { "dependencies": { "@rollup/pluginutils": "^5.1.0" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA=="],
 
-    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.48.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+XjmyChHfc4TSs6WUQGmVf7Hkg8ferMAE2aNYYWjiLzAS/T62uOsdfnqv+GHRjq7rKRnYh4mwWb4Hz7h/alp8A=="],
+    "@rollup/plugin-node-resolve": ["@rollup/plugin-node-resolve@16.0.1", "", { "dependencies": { "@rollup/pluginutils": "^5.0.1", "@types/resolve": "1.20.2", "deepmerge": "^4.2.2", "is-module": "^1.0.0", "resolve": "^1.22.1" }, "peerDependencies": { "rollup": "^2.78.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-tk5YCxJWIG81umIvNkSod2qK5KyQW19qcBF/B78n1bjtOON6gzKoVeSzAE8yHCZEDmqkHKkxplExA8KzdJLJpA=="],
 
-    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.48.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-upGEY7Ftw8M6BAJyGwnwMw91rSqXTcOKZnnveKrVWsMTF8/k5mleKSuh7D4v4IV1pLxKAk3Tbs0Lo9qYmii5mQ=="],
+    "@rollup/plugin-typescript": ["@rollup/plugin-typescript@12.1.4", "", { "dependencies": { "@rollup/pluginutils": "^5.1.0", "resolve": "^1.22.1" }, "peerDependencies": { "rollup": "^2.14.0||^3.0.0||^4.0.0", "tslib": "*", "typescript": ">=3.7.0" }, "optionalPeers": ["rollup", "tslib"] }, "sha512-s5Hx+EtN60LMlDBvl5f04bEiFZmAepk27Q+mr85L/00zPDn1jtzlTV6FWn81MaIwqfWzKxmOJrBWHU6vtQyedQ=="],
 
-    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.48.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-P9ViWakdoynYFUOZhqq97vBrhuvRLAbN/p2tAVJvhLb8SvN7rbBnJQcBu8e/rQts42pXGLVhfsAP0k9KXWa3nQ=="],
+    "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
 
-    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.48.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-VLKIwIpnBya5/saccM8JshpbxfyJt0Dsli0PjXozHwbSVaHTvWXJH1bbCwPXxnMzU4zVEfgD1HpW3VQHomi2AQ=="],
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.50.1", "", { "os": "android", "cpu": "arm" }, "sha512-HJXwzoZN4eYTdD8bVV22DN8gsPCAj3V20NHKOs8ezfXanGpmVPR7kalUHd+Y31IJp9stdB87VKPFbsGY3H/2ag=="],
 
-    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.48.1", "", { "os": "linux", "cpu": "arm" }, "sha512-3zEuZsXfKaw8n/yF7t8N6NNdhyFw3s8xJTqjbTDXlipwrEHo4GtIKcMJr5Ed29leLpB9AugtAQpAHW0jvtKKaQ=="],
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.50.1", "", { "os": "android", "cpu": "arm64" }, "sha512-PZlsJVcjHfcH53mOImyt3bc97Ep3FJDXRpk9sMdGX0qgLmY0EIWxCag6EigerGhLVuL8lDVYNnSo8qnTElO4xw=="],
 
-    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.48.1", "", { "os": "linux", "cpu": "arm" }, "sha512-leo9tOIlKrcBmmEypzunV/2w946JeLbTdDlwEZ7OnnsUyelZ72NMnT4B2vsikSgwQifjnJUbdXzuW4ToN1wV+Q=="],
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.50.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-xc6i2AuWh++oGi4ylOFPmzJOEeAa2lJeGUGb4MudOtgfyyjr4UPNK+eEWTPLvmPJIY/pgw6ssFIox23SyrkkJw=="],
 
-    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.48.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-Vy/WS4z4jEyvnJm+CnPfExIv5sSKqZrUr98h03hpAMbE2aI0aD2wvK6GiSe8Gx2wGp3eD81cYDpLLBqNb2ydwQ=="],
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.50.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-2ofU89lEpDYhdLAbRdeyz/kX3Y2lpYc6ShRnDjY35bZhd2ipuDMDi6ZTQ9NIag94K28nFMofdnKeHR7BT0CATw=="],
 
-    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.48.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-x5Kzn7XTwIssU9UYqWDB9VpLpfHYuXw5c6bJr4Mzv9kIv242vmJHbI5PJJEnmBYitUIfoMCODDhR7KoZLot2VQ=="],
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.50.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wOsE6H2u6PxsHY/BeFHA4VGQN3KUJFZp7QJBmDYI983fgxq5Th8FDkVuERb2l9vDMs1D5XhOrhBrnqcEY6l8ZA=="],
 
-    "@rollup/rollup-linux-loongarch64-gnu": ["@rollup/rollup-linux-loongarch64-gnu@4.48.1", "", { "os": "linux", "cpu": "none" }, "sha512-yzCaBbwkkWt/EcgJOKDUdUpMHjhiZT/eDktOPWvSRpqrVE04p0Nd6EGV4/g7MARXXeOqstflqsKuXVM3H9wOIQ=="],
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.50.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-A/xeqaHTlKbQggxCqispFAcNjycpUEHP52mwMQZUNqDUJFFYtPHCXS1VAG29uMlDzIVr+i00tSFWFLivMcoIBQ=="],
 
-    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.48.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-UK0WzWUjMAJccHIeOpPhPcKBqax7QFg47hwZTp6kiMhQHeOYJeaMwzeRZe1q5IiTKsaLnHu9s6toSYVUlZ2QtQ=="],
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.50.1", "", { "os": "linux", "cpu": "arm" }, "sha512-54v4okehwl5TaSIkpp97rAHGp7t3ghinRd/vyC1iXqXMfjYUTm7TfYmCzXDoHUPTTf36L8pr0E7YsD3CfB3ZDg=="],
 
-    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.48.1", "", { "os": "linux", "cpu": "none" }, "sha512-3NADEIlt+aCdCbWVZ7D3tBjBX1lHpXxcvrLt/kdXTiBrOds8APTdtk2yRL2GgmnSVeX4YS1JIf0imFujg78vpw=="],
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.50.1", "", { "os": "linux", "cpu": "arm" }, "sha512-p/LaFyajPN/0PUHjv8TNyxLiA7RwmDoVY3flXHPSzqrGcIp/c2FjwPPP5++u87DGHtw+5kSH5bCJz0mvXngYxw=="],
 
-    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.48.1", "", { "os": "linux", "cpu": "none" }, "sha512-euuwm/QTXAMOcyiFCcrx0/S2jGvFlKJ2Iro8rsmYL53dlblp3LkUQVFzEidHhvIPPvcIsxDhl2wkBE+I6YVGzA=="],
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.50.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-2AbMhFFkTo6Ptna1zO7kAXXDLi7H9fGTbVaIq2AAYO7yzcAsuTNWPHhb2aTA6GPiP+JXh85Y8CiS54iZoj4opw=="],
 
-    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.48.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-w8mULUjmPdWLJgmTYJx/W6Qhln1a+yqvgwmGXcQl2vFBkWsKGUBRbtLRuKJUln8Uaimf07zgJNxOhHOvjSQmBQ=="],
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.50.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-Cgef+5aZwuvesQNw9eX7g19FfKX5/pQRIyhoXLCiBOrWopjo7ycfB292TX9MDcDijiuIJlx1IzJz3IoCPfqs9w=="],
 
-    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.48.1", "", { "os": "linux", "cpu": "x64" }, "sha512-90taWXCWxTbClWuMZD0DKYohY1EovA+W5iytpE89oUPmT5O1HFdf8cuuVIylE6vCbrGdIGv85lVRzTcpTRZ+kA=="],
+    "@rollup/rollup-linux-loongarch64-gnu": ["@rollup/rollup-linux-loongarch64-gnu@4.50.1", "", { "os": "linux", "cpu": "none" }, "sha512-RPhTwWMzpYYrHrJAS7CmpdtHNKtt2Ueo+BlLBjfZEhYBhK00OsEqM08/7f+eohiF6poe0YRDDd8nAvwtE/Y62Q=="],
 
-    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.48.1", "", { "os": "linux", "cpu": "x64" }, "sha512-2Gu29SkFh1FfTRuN1GR1afMuND2GKzlORQUP3mNMJbqdndOg7gNsa81JnORctazHRokiDzQ5+MLE5XYmZW5VWg=="],
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.50.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eSGMVQw9iekut62O7eBdbiccRguuDgiPMsw++BVUg+1K7WjZXHOg/YOT9SWMzPZA+w98G+Fa1VqJgHZOHHnY0Q=="],
 
-    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.48.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-6kQFR1WuAO50bxkIlAVeIYsz3RUx+xymwhTo9j94dJ+kmHe9ly7muH23sdfWduD0BA8pD9/yhonUvAjxGh34jQ=="],
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.50.1", "", { "os": "linux", "cpu": "none" }, "sha512-S208ojx8a4ciIPrLgazF6AgdcNJzQE4+S9rsmOmDJkusvctii+ZvEuIC4v/xFqzbuP8yDjn73oBlNDgF6YGSXQ=="],
 
-    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.48.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-RUyZZ/mga88lMI3RlXFs4WQ7n3VyU07sPXmMG7/C1NOi8qisUg57Y7LRarqoGoAiopmGmChUhSwfpvQ3H5iGSQ=="],
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.50.1", "", { "os": "linux", "cpu": "none" }, "sha512-3Ag8Ls1ggqkGUvSZWYcdgFwriy2lWo+0QlYgEFra/5JGtAd6C5Hw59oojx1DeqcA2Wds2ayRgvJ4qxVTzCHgzg=="],
 
-    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.48.1", "", { "os": "win32", "cpu": "x64" }, "sha512-8a/caCUN4vkTChxkaIJcMtwIVcBhi4X2PQRoT+yCK3qRYaZ7cURrmJFL5Ux9H9RaMIXj9RuihckdmkBX3zZsgg=="],
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.50.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-t9YrKfaxCYe7l7ldFERE1BRg/4TATxIg+YieHQ966jwvo7ddHJxPj9cNFWLAzhkVsbBvNA4qTbPVNsZKBO4NSg=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.50.1", "", { "os": "linux", "cpu": "x64" }, "sha512-MCgtFB2+SVNuQmmjHf+wfI4CMxy3Tk8XjA5Z//A0AKD7QXUYFMQcns91K6dEHBvZPCnhJSyDWLApk40Iq/H3tA=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.50.1", "", { "os": "linux", "cpu": "x64" }, "sha512-nEvqG+0jeRmqaUMuwzlfMKwcIVffy/9KGbAGyoa26iu6eSngAYQ512bMXuqqPrlTyfqdlB9FVINs93j534UJrg=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.50.1", "", { "os": "none", "cpu": "arm64" }, "sha512-RDsLm+phmT3MJd9SNxA9MNuEAO/J2fhW8GXk62G/B4G7sLVumNFbRwDL6v5NrESb48k+QMqdGbHgEtfU0LCpbA=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.50.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-hpZB/TImk2FlAFAIsoElM3tLzq57uxnGYwplg6WDyAxbYczSi8O2eQ+H2Lx74504rwKtZ3N2g4bCUkiamzS6TQ=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.50.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-SXjv8JlbzKM0fTJidX4eVsH+Wmnp0/WcD8gJxIZyR6Gay5Qcsmdbi9zVtnbkGPG8v2vMR1AD06lGWy5FLMcG7A=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.50.1", "", { "os": "win32", "cpu": "x64" }, "sha512-StxAO/8ts62KZVRAm4JZYq9+NqNsV7RvimNK+YM7ry//zebEH6meuugqW/P5OFUCjyQgui+9fUxT6d5NShvMvA=="],
 
     "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
-    "@types/bun": ["@types/bun@1.2.20", "", { "dependencies": { "bun-types": "1.2.20" } }, "sha512-dX3RGzQ8+KgmMw7CsW4xT5ITBSCrSbfHc36SNT31EOUg/LA9JWq0VDdEXDRSe1InVWpd2yLUM1FUF/kEOyTzYA=="],
+    "@types/bun": ["@types/bun@1.2.21", "", { "dependencies": { "bun-types": "1.2.21" } }, "sha512-NiDnvEqmbfQ6dmZ3EeUO577s4P5bf4HCTXtI6trMc6f6RzirY5IrF3aIookuSpyslFzrnvv2lmEWv5HyC1X79A=="],
 
     "@types/chai": ["@types/chai@5.2.2", "", { "dependencies": { "@types/deep-eql": "*" } }, "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg=="],
 
@@ -288,15 +318,15 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
-    "@types/fs-extra": ["@types/fs-extra@11.0.4", "", { "dependencies": { "@types/jsonfile": "*", "@types/node": "*" } }, "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ=="],
+    "@types/inquirer": ["@types/inquirer@9.0.9", "", { "dependencies": { "@types/through": "*", "rxjs": "^7.2.0" } }, "sha512-/mWx5136gts2Z2e5izdoRCo46lPp5TMs9R15GTSsgg/XnZyxDWVqoVU3R9lWnccKpqwsJLvRoxbCjoJtZB7DSw=="],
 
-    "@types/jsonfile": ["@types/jsonfile@6.1.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ=="],
+    "@types/node": ["@types/node@24.3.1", "", { "dependencies": { "undici-types": "~7.10.0" } }, "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g=="],
 
-    "@types/node": ["@types/node@24.3.0", "", { "dependencies": { "undici-types": "~7.10.0" } }, "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow=="],
+    "@types/react": ["@types/react@19.1.12", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w=="],
 
-    "@types/prompts": ["@types/prompts@2.4.9", "", { "dependencies": { "@types/node": "*", "kleur": "^3.0.3" } }, "sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA=="],
+    "@types/resolve": ["@types/resolve@1.20.2", "", {}, "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="],
 
-    "@types/react": ["@types/react@19.1.11", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-lr3jdBw/BGj49Eps7EvqlUaoeA0xpj3pc0RoJkHpYaCHkVK7i28dKyImLQb3JVlqs3aYSXf7qYuWOW/fgZnTXQ=="],
+    "@types/through": ["@types/through@0.0.33", "", { "dependencies": { "@types/node": "*" } }, "sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ=="],
 
     "@vitest/coverage-v8": ["@vitest/coverage-v8@3.2.4", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "@bcoe/v8-coverage": "^1.0.2", "ast-v8-to-istanbul": "^0.3.3", "debug": "^4.4.1", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-lib-source-maps": "^5.0.6", "istanbul-reports": "^3.1.7", "magic-string": "^0.30.17", "magicast": "^0.3.5", "std-env": "^3.9.0", "test-exclude": "^7.0.1", "tinyrainbow": "^2.0.0" }, "peerDependencies": { "@vitest/browser": "3.2.4", "vitest": "3.2.4" }, "optionalPeers": ["@vitest/browser"] }, "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ=="],
 
@@ -320,11 +350,11 @@
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
-    "ansi-escapes": ["ansi-escapes@7.0.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw=="],
+    "ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
 
-    "ansi-regex": ["ansi-regex@6.2.0", "", {}, "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg=="],
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
-    "ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "anymatch": ["anymatch@1.3.2", "", { "dependencies": { "micromatch": "^2.1.5", "normalize-path": "^2.0.0" } }, "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA=="],
 
@@ -368,7 +398,7 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "bun-types": ["bun-types@1.2.20", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-pxTnQYOrKvdOwyiyd/7sMt9yFOenN004Y6O4lCcCUoKVej48FS5cvTw9geRaEcB9TsDZaJKAxPTVvi8tFsVuXA=="],
+    "bun-types": ["bun-types@1.2.21", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-sa2Tj77Ijc/NTLS0/Odjq/qngmEPZfbfnOERi0KRUYhT9R8M4VBioWVmMWE5GrYbKMc+5lVybXygLdibHaqVqw=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
@@ -378,7 +408,7 @@
 
     "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
 
-    "chalk": ["chalk@5.6.0", "", {}, "sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ=="],
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "chardet": ["chardet@2.1.0", "", {}, "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA=="],
 
@@ -396,6 +426,8 @@
 
     "cli-truncate": ["cli-truncate@4.0.0", "", { "dependencies": { "slice-ansi": "^5.0.0", "string-width": "^7.0.0" } }, "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA=="],
 
+    "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
+
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "collection-visit": ["collection-visit@1.0.0", "", { "dependencies": { "map-visit": "^1.0.0", "object-visit": "^1.0.0" } }, "sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw=="],
@@ -407,6 +439,8 @@
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
     "commander": ["commander@14.0.0", "", {}, "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA=="],
+
+    "commondir": ["commondir@1.0.1", "", {}, "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="],
 
     "compare-func": ["compare-func@2.0.0", "", { "dependencies": { "array-ify": "^1.0.0", "dot-prop": "^5.1.0" } }, "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA=="],
 
@@ -458,7 +492,7 @@
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
-    "emoji-regex": ["emoji-regex@10.4.0", "", {}, "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw=="],
+    "emoji-regex": ["emoji-regex@10.5.0", "", {}, "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg=="],
 
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
 
@@ -476,7 +510,7 @@
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
-    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
@@ -524,7 +558,7 @@
 
     "fragment-cache": ["fragment-cache@0.2.1", "", { "dependencies": { "map-cache": "^0.2.2" } }, "sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA=="],
 
-    "fs-extra": ["fs-extra@11.3.1", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g=="],
+    "fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
@@ -534,7 +568,7 @@
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
-    "get-east-asian-width": ["get-east-asian-width@1.3.0", "", {}, "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ=="],
+    "get-east-asian-width": ["get-east-asian-width@1.3.1", "", {}, "sha512-R1QfovbPsKmosqTnPoRFiJ7CF9MLRgb53ChvMZm+r4p76/+8yKDy17qLL2PKInORy2RkZZekuK0efYgmzTkXyQ=="],
 
     "get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
 
@@ -578,7 +612,7 @@
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
-    "import-meta-resolve": ["import-meta-resolve@4.1.0", "", {}, "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw=="],
+    "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
 
     "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
 
@@ -616,6 +650,8 @@
 
     "is-interactive": ["is-interactive@2.0.0", "", {}, "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="],
 
+    "is-module": ["is-module@1.0.0", "", {}, "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g=="],
+
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "is-obj": ["is-obj@2.0.0", "", {}, "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="],
@@ -627,6 +663,8 @@
     "is-posix-bracket": ["is-posix-bracket@0.1.1", "", {}, "sha512-Yu68oeXJ7LeWNmZ3Zov/xg/oDBnBK2RNxwYY1ilNJX+tKKZqgPK+qOn/Gs9jEu66KDY9Netf5XLKNGzas/vPfQ=="],
 
     "is-primitive": ["is-primitive@2.0.0", "", {}, "sha512-N3w1tFaRfk3UrPfqeRyD+GYDASU3W5VinKhlORy8EWVf/sIdDL9GAcew85XmktCfH+ngG7SRXEVDoO18WMdB/Q=="],
+
+    "is-reference": ["is-reference@1.2.1", "", { "dependencies": { "@types/estree": "*" } }, "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ=="],
 
     "is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
 
@@ -664,13 +702,11 @@
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
-    "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
+    "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
     "jsonparse": ["jsonparse@1.3.1", "", {}, "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="],
 
     "kind-of": ["kind-of@3.2.2", "", { "dependencies": { "is-buffer": "^1.1.5" } }, "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ=="],
-
-    "kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
     "lcid": ["lcid@3.1.1", "", { "dependencies": { "invert-kv": "^3.0.0" } }, "sha512-M6T051+5QCGLBQb8id3hdvIW8+zeFV2FyBGFS9IEK5H9Wt4MueD4bW1eWikpHgZp+5xR3l5c8pZUkQsIA0BFZg=="],
 
@@ -678,9 +714,9 @@
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
-    "lint-staged": ["lint-staged@16.1.5", "", { "dependencies": { "chalk": "^5.5.0", "commander": "^14.0.0", "debug": "^4.4.1", "lilconfig": "^3.1.3", "listr2": "^9.0.1", "micromatch": "^4.0.8", "nano-spawn": "^1.0.2", "pidtree": "^0.6.0", "string-argv": "^0.3.2", "yaml": "^2.8.1" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-uAeQQwByI6dfV7wpt/gVqg+jAPaSp8WwOA8kKC/dv1qw14oGpnpAisY65ibGHUGDUv0rYaZ8CAJZ/1U8hUvC2A=="],
+    "lint-staged": ["lint-staged@16.1.6", "", { "dependencies": { "chalk": "^5.6.0", "commander": "^14.0.0", "debug": "^4.4.1", "lilconfig": "^3.1.3", "listr2": "^9.0.3", "micromatch": "^4.0.8", "nano-spawn": "^1.0.2", "pidtree": "^0.6.0", "string-argv": "^0.3.2", "yaml": "^2.8.1" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-U4kuulU3CKIytlkLlaHcGgKscNfJPNTiDF2avIUGFCv7K95/DCYQ7Ra62ydeRWmgQGg9zJYw2dzdbztwJlqrow=="],
 
-    "listr2": ["listr2@9.0.2", "", { "dependencies": { "cli-truncate": "^4.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-VVd7cS6W+vLJu2wmq4QmfVj14Iep7cz4r/OWNk36Aq5ZOY7G8/BfCrQFexcwB1OIxB3yERiePfE/REBjEFulag=="],
+    "listr2": ["listr2@9.0.3", "", { "dependencies": { "cli-truncate": "^4.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-0aeh5HHHgmq1KRdMMDHfhMWQmIT/m7nRDTlxlFqni2Sp0had9baqsjJRvDGdlvgd6NmPE0nPloOipiQJGFtTHQ=="],
 
     "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
@@ -710,7 +746,7 @@
 
     "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
-    "magic-string": ["magic-string@0.30.18", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ=="],
+    "magic-string": ["magic-string@0.30.19", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw=="],
 
     "magicast": ["magicast@0.3.5", "", { "dependencies": { "@babel/parser": "^7.25.4", "@babel/types": "^7.25.4", "source-map-js": "^1.2.0" } }, "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ=="],
 
@@ -744,9 +780,11 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
+
     "nan": ["nan@2.23.0", "", {}, "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ=="],
 
-    "nano-spawn": ["nano-spawn@1.0.2", "", {}, "sha512-21t+ozMQDAL/UGgQVBbZ/xXvNO10++ZPuTmKRO8k9V3AClVRht49ahtDjfY8l1q6nSHOrE5ASfthzH3ol6R/hg=="],
+    "nano-spawn": ["nano-spawn@1.0.3", "", {}, "sha512-jtpsQDetTnvS2Ts1fiRdci5rx0VYws5jGyC+4IYOTnIQ/wwdf6JdomlHBwqC3bJYOvaKu0C2GSZ1A60anrYpaA=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
@@ -774,9 +812,7 @@
 
     "outdent": ["outdent@0.5.0", "", {}, "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q=="],
 
-    "oxlint": ["oxlint@1.12.0", "", { "optionalDependencies": { "@oxlint/darwin-arm64": "1.12.0", "@oxlint/darwin-x64": "1.12.0", "@oxlint/linux-arm64-gnu": "1.12.0", "@oxlint/linux-arm64-musl": "1.12.0", "@oxlint/linux-x64-gnu": "1.12.0", "@oxlint/linux-x64-musl": "1.12.0", "@oxlint/win32-arm64": "1.12.0", "@oxlint/win32-x64": "1.12.0", "oxlint-tsgolint": ">=0.0.1" }, "bin": { "oxlint": "bin/oxlint", "oxc_language_server": "bin/oxc_language_server" } }, "sha512-tBQ9aB00aYLlGXE21WJHnKQAI8xoi2V6Eiz/WvGV7FwU9YLYuNOurEEVbfoS5u0ODX8GLvGWj1fdHh5Rb74Kkw=="],
-
-    "oxlint-tsgolint": ["oxlint-tsgolint@0.0.4", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.0.4", "@oxlint-tsgolint/darwin-x64": "0.0.4", "@oxlint-tsgolint/linux-arm64": "0.0.4", "@oxlint-tsgolint/linux-x64": "0.0.4", "@oxlint-tsgolint/win32-arm64": "0.0.4", "@oxlint-tsgolint/win32-x64": "0.0.4" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-KFWVP+VU3ymgK/Dtuf6iRkqjo+aN42lS1YThY6JWlNi1GQqm7wtio/kAwssqDhm8kP+CVXbgZAtu1wgsK4XeTg=="],
+    "oxlint": ["oxlint@1.14.0", "", { "optionalDependencies": { "@oxlint/darwin-arm64": "1.14.0", "@oxlint/darwin-x64": "1.14.0", "@oxlint/linux-arm64-gnu": "1.14.0", "@oxlint/linux-arm64-musl": "1.14.0", "@oxlint/linux-x64-gnu": "1.14.0", "@oxlint/linux-x64-musl": "1.14.0", "@oxlint/win32-arm64": "1.14.0", "@oxlint/win32-x64": "1.14.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.1.5" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint", "oxc_language_server": "bin/oxc_language_server" } }, "sha512-oo0nq3zF9hmgATGc9esoMahLuEESOodUxEDeHDA2K7tbYcSfcmReE9G2QNppnq9rOSQHLTwlMtzGAjjttYaufQ=="],
 
     "p-filter": ["p-filter@2.1.0", "", { "dependencies": { "p-map": "^2.0.0" } }, "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw=="],
 
@@ -838,8 +874,6 @@
 
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
 
-    "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
-
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
@@ -882,9 +916,11 @@
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
-    "rollup": ["rollup@4.48.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.48.1", "@rollup/rollup-android-arm64": "4.48.1", "@rollup/rollup-darwin-arm64": "4.48.1", "@rollup/rollup-darwin-x64": "4.48.1", "@rollup/rollup-freebsd-arm64": "4.48.1", "@rollup/rollup-freebsd-x64": "4.48.1", "@rollup/rollup-linux-arm-gnueabihf": "4.48.1", "@rollup/rollup-linux-arm-musleabihf": "4.48.1", "@rollup/rollup-linux-arm64-gnu": "4.48.1", "@rollup/rollup-linux-arm64-musl": "4.48.1", "@rollup/rollup-linux-loongarch64-gnu": "4.48.1", "@rollup/rollup-linux-ppc64-gnu": "4.48.1", "@rollup/rollup-linux-riscv64-gnu": "4.48.1", "@rollup/rollup-linux-riscv64-musl": "4.48.1", "@rollup/rollup-linux-s390x-gnu": "4.48.1", "@rollup/rollup-linux-x64-gnu": "4.48.1", "@rollup/rollup-linux-x64-musl": "4.48.1", "@rollup/rollup-win32-arm64-msvc": "4.48.1", "@rollup/rollup-win32-ia32-msvc": "4.48.1", "@rollup/rollup-win32-x64-msvc": "4.48.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-jVG20NvbhTYDkGAty2/Yh7HK6/q3DGSRH4o8ALKGArmMuaauM9kLfoMZ+WliPwA5+JHr2lTn3g557FxBV87ifg=="],
+    "rollup": ["rollup@4.50.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.50.1", "@rollup/rollup-android-arm64": "4.50.1", "@rollup/rollup-darwin-arm64": "4.50.1", "@rollup/rollup-darwin-x64": "4.50.1", "@rollup/rollup-freebsd-arm64": "4.50.1", "@rollup/rollup-freebsd-x64": "4.50.1", "@rollup/rollup-linux-arm-gnueabihf": "4.50.1", "@rollup/rollup-linux-arm-musleabihf": "4.50.1", "@rollup/rollup-linux-arm64-gnu": "4.50.1", "@rollup/rollup-linux-arm64-musl": "4.50.1", "@rollup/rollup-linux-loongarch64-gnu": "4.50.1", "@rollup/rollup-linux-ppc64-gnu": "4.50.1", "@rollup/rollup-linux-riscv64-gnu": "4.50.1", "@rollup/rollup-linux-riscv64-musl": "4.50.1", "@rollup/rollup-linux-s390x-gnu": "4.50.1", "@rollup/rollup-linux-x64-gnu": "4.50.1", "@rollup/rollup-linux-x64-musl": "4.50.1", "@rollup/rollup-openharmony-arm64": "4.50.1", "@rollup/rollup-win32-arm64-msvc": "4.50.1", "@rollup/rollup-win32-ia32-msvc": "4.50.1", "@rollup/rollup-win32-x64-msvc": "4.50.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-78E9voJHwnXQMiQdiqswVLZwJIzdBKJ1GdI5Zx6XwoFKUIk09/sSrr+05QFzvYb8q6Y9pPV45zzDuYa3907TZA=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
@@ -907,8 +943,6 @@
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
-
-    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
 
@@ -952,7 +986,7 @@
 
     "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
-    "strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -980,7 +1014,7 @@
 
     "tinyexec": ["tinyexec@1.0.1", "", {}, "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw=="],
 
-    "tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ=="],
+    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
 
@@ -994,6 +1028,10 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
+
     "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
 
     "undici-types": ["undici-types@7.10.0", "", {}, "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="],
@@ -1002,7 +1040,7 @@
 
     "union-value": ["union-value@1.0.1", "", { "dependencies": { "arr-union": "^3.1.0", "get-value": "^2.0.6", "is-extendable": "^0.1.1", "set-value": "^2.0.1" } }, "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg=="],
 
-    "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
+    "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
     "unset-value": ["unset-value@1.0.0", "", { "dependencies": { "has-value": "^0.3.1", "isobject": "^3.0.0" } }, "sha512-PcA2tsuGSF9cnySLHTLSh2qrQiJ70mn+r+Glzxv2TWZblxsxCC52BDlZoPCsz7STd9pN7EZetkWZBAvk4cgZdQ=="],
 
@@ -1012,7 +1050,7 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
-    "vite": ["vite@7.1.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.14" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-OOUi5zjkDxYrKhTV3V7iKsoS37VUM7v40+HuwEmcrsf11Cdx9y3DIr2Px6liIcZFwt3XSRpQvFpL3WVy7ApkGw=="],
+    "vite": ["vite@7.1.5", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ=="],
 
     "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
 
@@ -1022,7 +1060,7 @@
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
-    "wrap-ansi": ["wrap-ansi@9.0.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q=="],
+    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -1040,25 +1078,17 @@
 
     "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
 
+    "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
+
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "@changesets/apply-release-plan/fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
-
     "@changesets/apply-release-plan/prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
-
-    "@changesets/cli/fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
-
-    "@changesets/config/fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
-
-    "@changesets/pre/fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
-
-    "@changesets/read/fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
-
-    "@changesets/write/fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 
     "@changesets/write/prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 
     "@commitlint/top-level/find-up": ["find-up@7.0.0", "", { "dependencies": { "locate-path": "^7.2.0", "path-exists": "^5.0.0", "unicorn-magic": "^0.1.0" } }, "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g=="],
+
+    "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
@@ -1072,7 +1102,11 @@
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
+    "@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
     "anymatch/micromatch": ["micromatch@2.3.11", "", { "dependencies": { "arr-diff": "^2.0.0", "array-unique": "^0.2.1", "braces": "^1.8.2", "expand-brackets": "^0.1.4", "extglob": "^0.3.1", "filename-regex": "^2.0.0", "is-extglob": "^1.0.0", "is-glob": "^2.0.1", "kind-of": "^3.0.2", "normalize-path": "^2.0.1", "object.omit": "^2.0.0", "parse-glob": "^3.0.4", "regex-cache": "^0.4.2" } }, "sha512-LnU2XFEk9xxSJ6rfgAry/ty5qwUTyHYOBU0g4R6tIw5ljwgGIBmiKhRWLw5NpMOnrgUNcDJ4WMp8rl3sYVHLNA=="],
+
+    "ast-v8-to-istanbul/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "base/define-property": ["define-property@1.0.0", "", { "dependencies": { "is-descriptor": "^1.0.0" } }, "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA=="],
 
@@ -1104,7 +1138,9 @@
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
-    "log-update/slice-ansi": ["slice-ansi@7.1.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg=="],
+    "log-update/ansi-escapes": ["ansi-escapes@7.0.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw=="],
+
+    "log-update/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
@@ -1166,45 +1202,19 @@
 
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
-    "@changesets/apply-release-plan/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
-
-    "@changesets/apply-release-plan/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
-
-    "@changesets/cli/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
-
-    "@changesets/cli/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
-
-    "@changesets/config/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
-
-    "@changesets/config/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
-
-    "@changesets/pre/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
-
-    "@changesets/pre/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
-
-    "@changesets/read/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
-
-    "@changesets/read/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
-
-    "@changesets/write/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
-
-    "@changesets/write/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
-
     "@commitlint/top-level/find-up/locate-path": ["locate-path@7.2.0", "", { "dependencies": { "p-locate": "^6.0.0" } }, "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA=="],
 
     "@commitlint/top-level/find-up/path-exists": ["path-exists@5.0.0", "", {}, "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ=="],
 
     "@commitlint/top-level/find-up/unicorn-magic": ["unicorn-magic@0.1.0", "", {}, "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ=="],
 
+    "@inquirer/core/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "@inquirer/core/wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
-
-    "@manypkg/find-root/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
-
-    "@manypkg/find-root/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
-
-    "@manypkg/get-packages/fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
-
-    "@manypkg/get-packages/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
     "anymatch/micromatch/braces": ["braces@1.8.5", "", { "dependencies": { "expand-range": "^1.8.1", "preserve": "^0.2.0", "repeat-element": "^1.1.2" } }, "sha512-xU7bpz2ytJl1bH9cgIurjpg/n8Gohy9GTw81heDYLJQ4RU60dlyJsa+atVF2pI0yMMvKxI9HkKwjePCj5XI1hw=="],
 
@@ -1228,7 +1238,7 @@
 
     "has-values/is-number/kind-of": ["kind-of@3.2.2", "", { "dependencies": { "is-buffer": "^1.1.5" } }, "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ=="],
 
-    "log-update/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.0.0", "", { "dependencies": { "get-east-asian-width": "^1.0.0" } }, "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA=="],
+    "log-update/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
     "object-copy/define-property/is-descriptor": ["is-descriptor@0.1.7", "", { "dependencies": { "is-accessor-descriptor": "^1.0.1", "is-data-descriptor": "^1.0.1" } }, "sha512-C3grZTvObeN1xud4cRWl366OMXZTj0+HGyk4hvfpx4ZHt1Pb60ANSXqCK7pdOTeUQpRzECBSTphqvD7U+l22Eg=="],
 
@@ -1265,6 +1275,10 @@
     "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@commitlint/top-level/find-up/locate-path/p-locate": ["p-locate@6.0.0", "", { "dependencies": { "p-limit": "^4.0.0" } }, "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw=="],
+
+    "@inquirer/core/wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "@inquirer/core/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "fast-glob/glob-parent/is-glob/is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 

--- a/packages/devkit/README.md
+++ b/packages/devkit/README.md
@@ -65,13 +65,31 @@ pnpm install -g scaffolder-toolkit
 yarn global add scaffolder-toolkit
 ```
 
-### Verify Installation
+### Usage
 
-To confirm everything is working, run the help command.
+Since this is a Node.js-based CLI, you can run it using your package manager's runner.
 
 ```bash
-dk --help
+# using bun
+bunx dk --help
+
+# using npm
+npx dk --help
+
+# using pnpm
+pnpx dk --help
+
+# using yarn
+yarn dk --help
 ```
+
+> **Advice:** To use the command directly as `dk`, consider creating an **alias** in your shell configuration file (e.g., `.bashrc`, `.zshrc`, or `config.fish`).
+>
+> ```bash
+> # Example for Bash or Zsh
+> echo 'alias dk="bunx dk"' >> ~/.zshrc
+> source ~/.zshrc
+> ```
 
 ---
 
@@ -347,7 +365,7 @@ This is the recommended approach for most developers. Simply add the `$schema` p
       "templates": {
         "react": {
           "description": "A robust React project with TypeScript",
-          "location": "https://github.com/IT-WIBRC/react-ts-template",
+          "location": "https://github.com/IT-WIBRC/react-ts-template.git",
           "alias": "rt"
         },
         "nextjs": {
@@ -395,7 +413,7 @@ You can also define an **`alias`** to make it easier to reference a specific tem
         },
         "from-github": {
           "description": "A template from a GitHub repository",
-          "location": "https://github.com/my-user/my-template-repo",
+          "location": "https://github.com/my-user/my-template-repo.git",
           "alias": "gh-template",
           "cacheStrategy": "daily"
         },

--- a/packages/devkit/__tests__/integrations/add-template.spec.ts
+++ b/packages/devkit/__tests__/integrations/add-template.spec.ts
@@ -8,7 +8,7 @@ import {
   beforeAll,
 } from "vitest";
 import { execa } from "execa";
-import fs from "fs-extra";
+import fs from "../../src/utils/fileSystem.js";
 import path from "path";
 import os from "os";
 import {
@@ -77,7 +77,7 @@ describe("dk add-template", () => {
 
   it("should successfully add a new template to the local config", async () => {
     const localConfigPath = path.join(tempDir, LOCAL_CONFIG_FILE_NAME);
-    await fs.writeJson(localConfigPath, baseLocalConfig, { spaces: 2 });
+    await fs.writeJson(localConfigPath, baseLocalConfig);
 
     const { exitCode, all } = await execa(
       "bun",
@@ -111,7 +111,7 @@ describe("dk add-template", () => {
       globalConfigDir,
       GLOBAL_CONFIG_FILE_NAME,
     );
-    await fs.writeJson(globalConfigPath, baseGlobalConfig, { spaces: 2 });
+    await fs.writeJson(globalConfigPath, baseGlobalConfig);
 
     const { exitCode, all } = await execa(
       "bun",
@@ -143,7 +143,7 @@ describe("dk add-template", () => {
 
   it("should fail to add a template if the language is not found", async () => {
     const localConfigPath = path.join(tempDir, LOCAL_CONFIG_FILE_NAME);
-    await fs.writeJson(localConfigPath, baseLocalConfig, { spaces: 2 });
+    await fs.writeJson(localConfigPath, baseLocalConfig);
 
     const { exitCode, all } = await execa(
       "bun",
@@ -167,7 +167,7 @@ describe("dk add-template", () => {
 
   it("should fail to add a template if the template name already exists", async () => {
     const localConfigPath = path.join(tempDir, LOCAL_CONFIG_FILE_NAME);
-    await fs.writeJson(localConfigPath, baseLocalConfig, { spaces: 2 });
+    await fs.writeJson(localConfigPath, baseLocalConfig);
 
     const { exitCode, all } = await execa(
       "bun",
@@ -191,7 +191,7 @@ describe("dk add-template", () => {
 
   it("should fail to add a template if the alias already exists", async () => {
     const localConfigPath = path.join(tempDir, LOCAL_CONFIG_FILE_NAME);
-    await fs.writeJson(localConfigPath, baseLocalConfig, { spaces: 2 });
+    await fs.writeJson(localConfigPath, baseLocalConfig);
 
     const { exitCode, all } = await execa(
       "bun",
@@ -260,7 +260,7 @@ describe("dk add-template", () => {
 
   it("should fail on an invalid cache strategy value", async () => {
     const localConfigPath = path.join(tempDir, LOCAL_CONFIG_FILE_NAME);
-    await fs.writeJson(localConfigPath, baseLocalConfig, { spaces: 2 });
+    await fs.writeJson(localConfigPath, baseLocalConfig);
 
     const { exitCode, all } = await execa(
       "bun",
@@ -286,7 +286,7 @@ describe("dk add-template", () => {
 
   it("should fail on an invalid package manager value", async () => {
     const localConfigPath = path.join(tempDir, LOCAL_CONFIG_FILE_NAME);
-    await fs.writeJson(localConfigPath, baseLocalConfig, { spaces: 2 });
+    await fs.writeJson(localConfigPath, baseLocalConfig);
 
     const { exitCode, all } = await execa(
       "bun",

--- a/packages/devkit/__tests__/integrations/configs.spec.ts
+++ b/packages/devkit/__tests__/integrations/configs.spec.ts
@@ -8,7 +8,7 @@ import {
   beforeAll,
 } from "vitest";
 import { execa } from "execa";
-import fs from "fs-extra";
+import fs from "../../src/utils/fileSystem.js";
 import path from "path";
 import os from "os";
 import {
@@ -36,7 +36,6 @@ describe("dk config commands", () => {
     await fs.writeJson(
       path.join(tempDir, LOCAL_CONFIG_FILE_NAME),
       defaultCliConfig,
-      { spaces: 2 },
     );
   });
 
@@ -54,7 +53,7 @@ describe("dk config commands", () => {
       );
 
       expect(exitCode).toBe(0);
-      expect(all).toContain("✔ Configuration updated successfully!");
+      expect(all).toContain("✅ Configuration updated successfully!");
 
       const configContent = await fs.readJson(
         path.join(tempDir, LOCAL_CONFIG_FILE_NAME),
@@ -70,7 +69,7 @@ describe("dk config commands", () => {
       );
 
       expect(exitCode).toBe(0);
-      expect(all).toContain("✔ Configuration updated successfully!");
+      expect(all).toContain("✅ Configuration updated successfully!");
 
       const configContent = await fs.readJson(
         path.join(tempDir, LOCAL_CONFIG_FILE_NAME),
@@ -89,7 +88,7 @@ describe("dk config commands", () => {
         tempGlobalHome,
         GLOBAL_CONFIG_FILE_NAME,
       );
-      await fs.writeJson(globalConfigPath, defaultCliConfig, { spaces: 2 });
+      await fs.writeJson(globalConfigPath, defaultCliConfig);
 
       const { all, exitCode } = await execa(
         "bun",
@@ -98,7 +97,7 @@ describe("dk config commands", () => {
       );
 
       expect(exitCode).toBe(0);
-      expect(all).toContain("✔ Configuration updated successfully!");
+      expect(all).toContain("✅ Configuration updated successfully!");
 
       const globalConfigContent = await fs.readJson(globalConfigPath);
       expect(globalConfigContent.settings.language).toBe("fr");
@@ -163,7 +162,7 @@ describe("dk config commands", () => {
       );
 
       expect(exitCode).toBe(0);
-      expect(all).toContain("✔ Configuration loaded successfully!");
+      expect(all).toContain("✅ Configuration loaded successfully!");
       expect(all).toContain("Using local configuration.");
       expect(all).toContain("language: en");
     });
@@ -176,7 +175,7 @@ describe("dk config commands", () => {
       );
 
       expect(exitCode).toBe(0);
-      expect(all).toContain("✔ Configuration loaded successfully!");
+      expect(all).toContain("✅ Configuration loaded successfully!");
       expect(all).toContain("defaultPackageManager: bun");
     });
 
@@ -201,7 +200,7 @@ describe("dk config commands", () => {
       );
 
       expect(exitCode).toBe(0);
-      expect(all).toContain("✔ Configuration loaded successfully!");
+      expect(all).toContain("✅ Configuration loaded successfully!");
       expect(all).toContain("Using local configuration.");
       expect(all).toContain('"language": "en"');
       expect(all).toContain('"defaultPackageManager": "bun"');
@@ -217,14 +216,10 @@ describe("dk config commands", () => {
         tempGlobalHome,
         GLOBAL_CONFIG_FILE_NAME,
       );
-      await fs.writeJson(
-        globalConfigPath,
-        {
-          ...defaultCliConfig,
-          settings: { ...defaultCliConfig.settings, language: "fr" },
-        },
-        { spaces: 2 },
-      );
+      await fs.writeJson(globalConfigPath, {
+        ...defaultCliConfig,
+        settings: { ...defaultCliConfig.settings, language: "fr" },
+      });
 
       const { all, exitCode } = await execa(
         "bun",
@@ -233,7 +228,7 @@ describe("dk config commands", () => {
       );
 
       expect(exitCode).toBe(0);
-      expect(all).toContain("✔ Configuration loaded successfully!");
+      expect(all).toContain("✅ Configuration loaded successfully!");
       expect(all).toContain("Using global configuration.");
       expect(all).toContain("language: fr");
 
@@ -267,7 +262,7 @@ describe("dk config commands", () => {
       );
 
       expect(exitCode).toBe(0);
-      expect(all).toContain("✔ Configuration loaded successfully!");
+      expect(all).toContain("✅ Configuration loaded successfully!");
       expect(all).toContain(
         "No local configuration file found. Displaying global settings instead.",
       );
@@ -291,7 +286,7 @@ describe("dk config commands", () => {
       );
 
       expect(exitCode).toBe(0);
-      expect(all).toContain("✔ Configuration loaded successfully!");
+      expect(all).toContain("✅ Configuration loaded successfully!");
       expect(all).toContain(
         "No local configuration file found. Displaying default settings instead.",
       );

--- a/packages/devkit/__tests__/integrations/init.spec.ts
+++ b/packages/devkit/__tests__/integrations/init.spec.ts
@@ -8,7 +8,7 @@ import {
   beforeAll,
 } from "vitest";
 import { execa } from "execa";
-import fs from "fs-extra";
+import fs from "../../src/utils/fileSystem.js";
 import path from "path";
 import os from "os";
 import {
@@ -46,7 +46,7 @@ describe("dk init", () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(all).toContain("✔ Configuration file created successfully!");
+    expect(all).toContain("✅ Configuration file created successfully!");
     const configPath = path.join(tempDir, LOCAL_CONFIG_FILE_NAME);
     const fileExists = await fs.pathExists(configPath);
     expect(fileExists).toBe(true);
@@ -69,7 +69,7 @@ describe("dk init", () => {
     );
 
     expect(exitCode).toBe(0);
-    expect(all).toContain("✔ Configuration file created successfully!");
+    expect(all).toContain("✅ Configuration file created successfully!");
     const fileExists = await fs.pathExists(globalConfigPath);
     expect(fileExists).toBe(true);
 
@@ -96,13 +96,7 @@ describe("dk init with existing file", () => {
     tempDir = path.join(os.tmpdir(), `devkit-test-${Date.now()}`);
     await fs.ensureDir(tempDir);
     process.chdir(tempDir);
-    await fs.writeJson(
-      path.join(tempDir, LOCAL_CONFIG_FILE_NAME),
-      basicConfig,
-      {
-        spaces: 2,
-      },
-    );
+    await fs.writeJson(path.join(tempDir, LOCAL_CONFIG_FILE_NAME), basicConfig);
   });
 
   afterEach(async () => {
@@ -120,7 +114,6 @@ describe("dk init with existing file", () => {
     expect(all).toContain("Operation aborted.");
     const newContent = await fs.readJson(
       path.join(tempDir, LOCAL_CONFIG_FILE_NAME),
-      "utf-8",
     );
     expect(newContent).toEqual(basicConfig);
   });
@@ -132,10 +125,9 @@ describe("dk init with existing file", () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(all).toContain("✔ Configuration file created successfully!");
+    expect(all).toContain("✅ Configuration file created successfully!");
     const newContent = await fs.readJson(
       path.join(tempDir, LOCAL_CONFIG_FILE_NAME),
-      "utf-8",
     );
     expect(newContent).not.toEqual(basicConfig);
     expect(newContent).toEqual(defaultCliConfig);
@@ -179,7 +171,7 @@ describe("dk init in a monorepo", () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(all).toContain("✔ Configuration file created successfully!");
+    expect(all).toContain("✅ Configuration file created successfully!");
     const rootConfigPath = path.join(tempDir, LOCAL_CONFIG_FILE_NAME);
     const fileExists = await fs.pathExists(rootConfigPath);
     expect(fileExists).toBe(true);
@@ -203,7 +195,7 @@ describe("dk init in a monorepo", () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(all).toContain("✔ Configuration file created successfully!");
+    expect(all).toContain("✅ Configuration file created successfully!");
     const nestedConfigPath = path.join(
       nestedPackagePath,
       LOCAL_CONFIG_FILE_NAME,
@@ -223,7 +215,7 @@ describe("dk init in a monorepo", () => {
     const rootConfigContent = {
       settings: { defaultPackageManager: "yarn" },
     };
-    await fs.writeJson(rootConfigPath, rootConfigContent, { spaces: 2 });
+    await fs.writeJson(rootConfigPath, rootConfigContent);
 
     const { all, exitCode } = await execa("bun", [CLI_PATH, "init"], {
       all: true,
@@ -232,7 +224,7 @@ describe("dk init in a monorepo", () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(all).toContain("✔ Configuration file created successfully!");
+    expect(all).toContain("✅ Configuration file created successfully!");
 
     const newContent = await fs.readJson(rootConfigPath);
     expect(newContent).toEqual(defaultCliConfig);
@@ -243,7 +235,7 @@ describe("dk init in a monorepo", () => {
     const rootConfigContent = {
       settings: { defaultPackageManager: "yarn" },
     };
-    await fs.writeJson(rootConfigPath, rootConfigContent, { spaces: 2 });
+    await fs.writeJson(rootConfigPath, rootConfigContent);
 
     const { all, exitCode } = await execa("bun", [CLI_PATH, "init"], {
       all: true,
@@ -263,7 +255,7 @@ describe("dk init in a monorepo", () => {
     const rootConfigContent = {
       settings: { language: "en" },
     };
-    await fs.writeJson(rootConfigPath, rootConfigContent, { spaces: 2 });
+    await fs.writeJson(rootConfigPath, rootConfigContent);
 
     const nestedPackagePath = path.join(tempDir, "packages", "my-app");
     const nestedConfigPath = path.join(
@@ -277,9 +269,15 @@ describe("dk init in a monorepo", () => {
       input: "\n",
     });
 
+    const cleanedOutput = all
+      .replace(/\u001b\[.*?m/g, "")
+      .replace(/\s+/g, " ")
+      .trim();
     expect(exitCode).toBe(0);
-    expect(all).toContain("✔ Configuration file created successfully!");
-    expect(all).toContain(
+    expect(cleanedOutput).toContain(
+      "✅ Configuration file created successfully!",
+    );
+    expect(cleanedOutput).toContain(
       `A config file exists in the monorepo root at ${rootConfigPath}. Do you want to create a new one in the current package?`,
     );
 
@@ -298,7 +296,7 @@ describe("dk init in a monorepo", () => {
     const rootConfigContent = {
       settings: { language: "en" },
     };
-    await fs.writeJson(rootConfigPath, rootConfigContent, { spaces: 2 });
+    await fs.writeJson(rootConfigPath, rootConfigContent);
 
     const nestedPackagePath = path.join(tempDir, "packages", "my-app");
     const nestedConfigPath = path.join(

--- a/packages/devkit/__tests__/integrations/list.spec.ts
+++ b/packages/devkit/__tests__/integrations/list.spec.ts
@@ -8,7 +8,7 @@ import {
   beforeAll,
 } from "vitest";
 import { execa } from "execa";
-import fs from "fs-extra";
+import fs from "../../src/utils/fileSystem.js";
 import path from "path";
 import os from "os";
 import {
@@ -89,15 +89,10 @@ describe("dk list", () => {
   });
 
   it("should list templates from local config by default when it exists", async () => {
-    await fs.writeJson(
-      path.join(tempDir, LOCAL_CONFIG_FILE_NAME),
-      localConfig,
-      { spaces: 2 },
-    );
+    await fs.writeJson(path.join(tempDir, LOCAL_CONFIG_FILE_NAME), localConfig);
     await fs.writeJson(
       path.join(globalConfigDir, GLOBAL_CONFIG_FILE_NAME),
       globalConfig,
-      { spaces: 2 },
     );
 
     const { all, exitCode } = await execa("bun", [CLI_PATH, "list"], {
@@ -116,7 +111,6 @@ describe("dk list", () => {
     await fs.writeJson(
       path.join(globalConfigDir, GLOBAL_CONFIG_FILE_NAME),
       globalConfig,
-      { spaces: 2 },
     );
 
     const { all, exitCode } = await execa("bun", [CLI_PATH, "list"], {
@@ -135,15 +129,10 @@ describe("dk list", () => {
   });
 
   it("should list templates from both local and global configurations when --all is used", async () => {
-    await fs.writeJson(
-      path.join(tempDir, LOCAL_CONFIG_FILE_NAME),
-      localConfig,
-      { spaces: 2 },
-    );
+    await fs.writeJson(path.join(tempDir, LOCAL_CONFIG_FILE_NAME), localConfig);
     await fs.writeJson(
       path.join(globalConfigDir, GLOBAL_CONFIG_FILE_NAME),
       globalConfig,
-      { spaces: 2 },
     );
 
     const { all, exitCode } = await execa("bun", [CLI_PATH, "list", "--all"], {
@@ -159,15 +148,10 @@ describe("dk list", () => {
   });
 
   it("should only list templates from local config when --local is used", async () => {
-    await fs.writeJson(
-      path.join(tempDir, LOCAL_CONFIG_FILE_NAME),
-      localConfig,
-      { spaces: 2 },
-    );
+    await fs.writeJson(path.join(tempDir, LOCAL_CONFIG_FILE_NAME), localConfig);
     await fs.writeJson(
       path.join(globalConfigDir, GLOBAL_CONFIG_FILE_NAME),
       globalConfig,
-      { spaces: 2 },
     );
 
     const { all, exitCode } = await execa(
@@ -188,15 +172,10 @@ describe("dk list", () => {
   });
 
   it("should only list templates from global config when --global is used", async () => {
-    await fs.writeJson(
-      path.join(tempDir, LOCAL_CONFIG_FILE_NAME),
-      localConfig,
-      { spaces: 2 },
-    );
+    await fs.writeJson(path.join(tempDir, LOCAL_CONFIG_FILE_NAME), localConfig);
     await fs.writeJson(
       path.join(globalConfigDir, GLOBAL_CONFIG_FILE_NAME),
       globalConfig,
-      { spaces: 2 },
     );
 
     const { all, exitCode } = await execa(
@@ -217,11 +196,7 @@ describe("dk list", () => {
   });
 
   it("should show an error if a language filter is provided but no templates are found for it", async () => {
-    await fs.writeJson(
-      path.join(tempDir, LOCAL_CONFIG_FILE_NAME),
-      localConfig,
-      { spaces: 2 },
-    );
+    await fs.writeJson(path.join(tempDir, LOCAL_CONFIG_FILE_NAME), localConfig);
     const { all, exitCode } = await execa("bun", [CLI_PATH, "list", "rust"], {
       all: true,
       env: { HOME: globalConfigDir },
@@ -236,17 +211,13 @@ describe("dk list", () => {
 
   it("should handle a config file with an empty templates section", async () => {
     const emptyConfig = { ...localConfig, templates: {} };
-    await fs.writeJson(
-      path.join(tempDir, LOCAL_CONFIG_FILE_NAME),
-      emptyConfig,
-      { spaces: 2 },
-    );
+    await fs.writeJson(path.join(tempDir, LOCAL_CONFIG_FILE_NAME), emptyConfig);
     const { all, exitCode } = await execa("bun", [CLI_PATH, "list"], {
       all: true,
       env: { HOME: globalConfigDir },
     });
 
     expect(exitCode).toBe(0);
-    expect(all).toContain("✔ No templates found in the configuration file.");
+    expect(all).toContain("✅ No templates found in the configuration file.");
   });
 });

--- a/packages/devkit/__tests__/integrations/new.spec.ts
+++ b/packages/devkit/__tests__/integrations/new.spec.ts
@@ -8,7 +8,7 @@ import {
   vi,
 } from "vitest";
 import { execa } from "execa";
-import fs from "fs-extra";
+import fs from "../../src/utils/fileSystem.js";
 import path from "path";
 import os from "os";
 import {
@@ -106,24 +106,23 @@ describe("dk new", () => {
       await fs.writeJson(
         path.join(mockInstallDir, LOCAL_CONFIG_FILE_NAME),
         configWithTemplates,
-        { spaces: 2 },
       );
 
       await fs.ensureDir(path.join(templatesDir, "vuejs"));
-      await fs.writeFile(
-        path.join(templatesDir, "vuejs", "package.json"),
-        JSON.stringify({ name: "test-vue-template" }),
-      );
+
+      await fs.writeFile(path.join(templatesDir, "vuejs", "package.json"), {
+        name: "test-vue-template",
+      });
+
       await fs.writeFile(
         path.join(templatesDir, "vuejs", "vue-test.txt"),
         "vue content",
       );
 
       await fs.ensureDir(path.join(templatesDir, "nestjs"));
-      await fs.writeFile(
-        path.join(templatesDir, "nestjs", "package.json"),
-        JSON.stringify({ name: "test-nest-template" }),
-      );
+      await fs.writeFile(path.join(templatesDir, "nestjs", "package.json"), {
+        name: "test-nest-template",
+      });
       await fs.writeFile(
         path.join(templatesDir, "nestjs", "nest-test.txt"),
         "nestjs content",
@@ -154,7 +153,7 @@ describe("dk new", () => {
           path.join(mockProjectDir, "my-vue-app", "vue-test.txt"),
         ),
       ).toBe(true);
-    });
+    }, 10000);
   });
 
   describe("dk new (Monorepo Usage)", () => {
@@ -183,7 +182,6 @@ describe("dk new", () => {
       await fs.writeJson(
         path.join(tempDir, LOCAL_CONFIG_FILE_NAME),
         configWithTemplates,
-        { spaces: 2 },
       );
 
       await fs.ensureDir(path.join(packagesTemplatesJsDir, "vuejs"));
@@ -199,7 +197,7 @@ describe("dk new", () => {
       await fs.ensureDir(path.join(packagesTemplatesJsDir, "nestjs"));
       await fs.writeFile(
         path.join(packagesTemplatesJsDir, "nestjs", "package.json"),
-        JSON.stringify({ name: "test-nest-template" }),
+        { name: "test-nest-template" },
       );
       await fs.writeFile(
         path.join(packagesTemplatesJsDir, "nestjs", "nest-test.txt"),

--- a/packages/devkit/__tests__/integrations/remove-template.spec.ts
+++ b/packages/devkit/__tests__/integrations/remove-template.spec.ts
@@ -8,7 +8,7 @@ import {
   beforeAll,
 } from "vitest";
 import { execa } from "execa";
-import fs from "fs-extra";
+import fs from "../../src/utils/fileSystem.js";
 import path from "path";
 import os from "os";
 import {
@@ -95,7 +95,7 @@ describe("dk remove-template", () => {
 
   it("should successfully remove a template from the local config", async () => {
     const localConfigPath = path.join(tempDir, LOCAL_CONFIG_FILE_NAME);
-    await fs.writeJson(localConfigPath, localConfig, { spaces: 2 });
+    await fs.writeJson(localConfigPath, localConfig);
 
     const { exitCode, all } = await execa(
       "bun",
@@ -120,7 +120,7 @@ describe("dk remove-template", () => {
 
   it("should successfully remove a template using an alias from the local config", async () => {
     const localConfigPath = path.join(tempDir, LOCAL_CONFIG_FILE_NAME);
-    await fs.writeJson(localConfigPath, localConfig, { spaces: 2 });
+    await fs.writeJson(localConfigPath, localConfig);
 
     const { exitCode, all } = await execa(
       "bun",
@@ -147,7 +147,7 @@ describe("dk remove-template", () => {
       globalConfigDir,
       GLOBAL_CONFIG_FILE_NAME,
     );
-    await fs.writeJson(globalConfigPath, globalConfig, { spaces: 2 });
+    await fs.writeJson(globalConfigPath, globalConfig);
 
     const { exitCode, all } = await execa(
       "bun",
@@ -186,7 +186,7 @@ describe("dk remove-template", () => {
 
   it("should fail to remove a template if the specified language is not found", async () => {
     const localConfigPath = path.join(tempDir, LOCAL_CONFIG_FILE_NAME);
-    await fs.writeJson(localConfigPath, localConfig, { spaces: 2 });
+    await fs.writeJson(localConfigPath, localConfig);
 
     const { exitCode, all } = await execa(
       "bun",
@@ -206,7 +206,7 @@ describe("dk remove-template", () => {
 
   it("should fail to remove a template if the template name/alias is not found", async () => {
     const localConfigPath = path.join(tempDir, LOCAL_CONFIG_FILE_NAME);
-    await fs.writeJson(localConfigPath, localConfig, { spaces: 2 });
+    await fs.writeJson(localConfigPath, localConfig);
 
     const { exitCode, all } = await execa(
       "bun",

--- a/packages/devkit/__tests__/integrations/update.spec.ts
+++ b/packages/devkit/__tests__/integrations/update.spec.ts
@@ -8,7 +8,7 @@ import {
   beforeAll,
 } from "vitest";
 import { execa } from "execa";
-import fs from "fs-extra";
+import fs from "../../src/utils/fileSystem.js";
 import path from "path";
 import os from "os";
 import { CONFIG_FILE_NAMES } from "../../src/utils/configs/schema.js";

--- a/packages/devkit/__tests__/units/utils/cache/fs-manager.spec.ts
+++ b/packages/devkit/__tests__/units/utils/cache/fs-manager.spec.ts
@@ -7,11 +7,9 @@ import {
 const mockStat = vi.hoisted(() => vi.fn());
 const mockCopy = vi.hoisted(() => vi.fn());
 
-vi.mock("fs-extra", () => ({
+vi.mock("#utils/fileSystem.js", () => ({
   default: {
-    promises: {
-      stat: mockStat,
-    },
+    stat: mockStat,
     copy: mockCopy,
   },
 }));

--- a/packages/devkit/__tests__/units/utils/cache/git.spec.ts
+++ b/packages/devkit/__tests__/units/utils/cache/git.spec.ts
@@ -16,12 +16,10 @@ vi.mock("execa", () => ({
   execa: mockExeca,
 }));
 
-vi.mock("fs-extra", () => ({
+vi.mock("#utils/fileSystem.js", () => ({
   default: {
     ensureDir: mockEnsureDir,
-    promises: {
-      stat: mockStat,
-    },
+    stat: mockStat,
   },
 }));
 

--- a/packages/devkit/__tests__/units/utils/configs/loader.spec.ts
+++ b/packages/devkit/__tests__/units/utils/configs/loader.spec.ts
@@ -41,7 +41,7 @@ vi.mock("#utils/configs/reader.js", () => ({
   readConfigAtPath: mockReadConfigAtPath,
 }));
 
-vi.mock("fs-extra", () => ({
+vi.mock("#utils/fileSystem.js", () => ({
   default: {
     pathExists: mockFs.pathExists,
     readJson: mockFs.readJson,

--- a/packages/devkit/__tests__/units/utils/configs/reader.spec.ts
+++ b/packages/devkit/__tests__/units/utils/configs/reader.spec.ts
@@ -14,8 +14,10 @@ const { mockExistsSync, mockGetConfigFilePath, mockReadFile } = vi.hoisted(
   }),
 );
 
-vi.mock("fs-extra", () => ({
-  existsSync: mockExistsSync,
+vi.mock("#utils/fileSystem.js", () => ({
+  default: {
+    existsSync: mockExistsSync,
+  },
 }));
 
 vi.mock("fs/promises", () => ({

--- a/packages/devkit/__tests__/units/utils/configs/writer.spec.ts
+++ b/packages/devkit/__tests__/units/utils/configs/writer.spec.ts
@@ -1,5 +1,4 @@
 import { vi, describe, it, expect, beforeEach } from "vitest";
-import fs from "fs-extra";
 import {
   saveConfig,
   saveCliConfig,
@@ -13,7 +12,7 @@ const { mockWriteJson, mockGetConfigFilepath } = vi.hoisted(() => ({
   mockGetConfigFilepath: vi.fn(),
 }));
 
-vi.mock("fs-extra", () => ({
+vi.mock("#utils/fileSystem.js", () => ({
   default: {
     writeJson: mockWriteJson,
   },
@@ -43,9 +42,7 @@ describe("Configuration Writer Functions", () => {
     const config = { setting: "value" };
     mockWriteJson.mockResolvedValueOnce(undefined);
     await saveConfig(config as any, filePath);
-    expect(vi.mocked(fs.writeJson)).toHaveBeenCalledWith(filePath, config, {
-      spaces: 2,
-    });
+    expect(mockWriteJson).toHaveBeenCalledWith(filePath, config);
   });
 
   it("saveConfig should throw a DevkitError on write failure", async () => {
@@ -64,10 +61,9 @@ describe("Configuration Writer Functions", () => {
     mockWriteJson.mockResolvedValueOnce(undefined);
     await saveCliConfig({} as any, false);
     expect(vi.mocked(getConfigFilepath)).toHaveBeenCalledWith(false);
-    expect(vi.mocked(fs.writeJson)).toHaveBeenCalledWith(
+    expect(mockWriteJson).toHaveBeenCalledWith(
       "/cli/config.json",
       expect.any(Object),
-      { spaces: 2 },
     );
   });
 
@@ -82,7 +78,6 @@ describe("Configuration Writer Functions", () => {
     expect(mockWriteJson).toHaveBeenCalledWith(
       "/project/config.json",
       expect.any(Object),
-      { spaces: 2 },
     );
   });
 

--- a/packages/devkit/__tests__/units/utils/fileSystem.spec.ts
+++ b/packages/devkit/__tests__/units/utils/fileSystem.spec.ts
@@ -1,0 +1,258 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import fileSystem from "../../../src/utils/fileSystem.js";
+
+const {
+  mockWriteFile,
+  mockReadFile,
+  mockStat,
+  mockReaddir,
+  mockCopyFile,
+  mockMkdir,
+  mockRm,
+  mockAccess,
+  mockExistsSync,
+} = vi.hoisted(() => ({
+  mockWriteFile: vi.fn(),
+  mockReadFile: vi.fn(),
+  mockStat: vi.fn(),
+  mockReaddir: vi.fn(),
+  mockCopyFile: vi.fn(),
+  mockMkdir: vi.fn(),
+  mockRm: vi.fn(),
+  mockAccess: vi.fn(),
+  mockExistsSync: vi.fn(),
+}));
+
+vi.mock("fs", () => ({
+  promises: {
+    writeFile: mockWriteFile,
+    readFile: mockReadFile,
+    stat: mockStat,
+    readdir: mockReaddir,
+    copyFile: mockCopyFile,
+    mkdir: mockMkdir,
+    rm: mockRm,
+    access: mockAccess,
+  },
+  existsSync: mockExistsSync,
+}));
+
+vi.mock("path", async () => {
+  const actual = await vi.importActual("path");
+  return {
+    ...(actual as object),
+    resolve: vi.fn(),
+    join: vi.fn().mockImplementation((...args) => args.join("/")),
+  };
+});
+
+describe("fileSystem", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("readJson", () => {
+    it("should read a JSON file and return the parsed content", async () => {
+      mockReadFile.mockResolvedValueOnce(JSON.stringify({ name: "test" }));
+      const data = await fileSystem.readJson("path/to/file.json");
+      expect(mockReadFile).toHaveBeenCalledWith("path/to/file.json", {
+        encoding: "utf8",
+      });
+      expect(data).toEqual({ name: "test" });
+    });
+
+    it("should throw an error if the file cannot be read", async () => {
+      const readError = new Error("File not found");
+      mockReadFile.mockRejectedValue(readError);
+      await expect(fileSystem.readJson("path/to/file.json")).rejects.toThrow(
+        readError,
+      );
+    });
+  });
+
+  describe("writeJson", () => {
+    it("should write data to a JSON file", async () => {
+      const data = { name: "test" };
+      await fileSystem.writeJson("path/to/file.json", data);
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        "path/to/file.json",
+        JSON.stringify(data, null, 2),
+      );
+    });
+
+    it("should throw an error if the file cannot be written", async () => {
+      const writeError = new Error("Permission denied");
+      mockWriteFile.mockRejectedValue(writeError);
+      await expect(
+        fileSystem.writeJson("path/to/file.json", {}),
+      ).rejects.toThrow(writeError);
+    });
+  });
+
+  describe("existsSync", () => {
+    it("should return true if the path exists", () => {
+      mockExistsSync.mockReturnValueOnce(true);
+      expect(fileSystem.existsSync("path/to/file")).toBe(true);
+      expect(mockExistsSync).toHaveBeenCalledWith("path/to/file");
+    });
+
+    it("should return false if the path does not exist", () => {
+      mockExistsSync.mockReturnValueOnce(false);
+      expect(fileSystem.existsSync("path/to/file")).toBe(false);
+      expect(mockExistsSync).toHaveBeenCalledWith("path/to/file");
+    });
+  });
+
+  describe("copy", () => {
+    it("should copy a file without a filter", async () => {
+      mockStat.mockResolvedValueOnce({
+        isFile: () => true,
+        isDirectory: () => false,
+      });
+      await fileSystem.copy("src/file.js", "dest/file.js");
+      expect(mockStat).toHaveBeenCalledWith("src/file.js");
+      expect(mockCopyFile).toHaveBeenCalledWith("src/file.js", "dest/file.js");
+    });
+
+    it("should copy a directory recursively", async () => {
+      mockStat
+        .mockResolvedValueOnce({
+          isFile: () => false,
+          isDirectory: () => true,
+        })
+        .mockResolvedValueOnce({
+          isFile: () => true,
+          isDirectory: () => false,
+        });
+      mockReaddir.mockResolvedValueOnce(["file.js"]);
+      mockMkdir.mockResolvedValueOnce(undefined);
+      mockCopyFile.mockResolvedValueOnce(undefined);
+      await fileSystem.copy("src/dir", "dest/dir");
+      expect(mockStat).toHaveBeenCalledWith("src/dir");
+      expect(mockMkdir).toHaveBeenCalledWith("dest/dir", { recursive: true });
+      expect(mockReaddir).toHaveBeenCalledWith("src/dir");
+      expect(mockCopyFile).toHaveBeenCalledWith(
+        "src/dir/file.js",
+        "dest/dir/file.js",
+      );
+    });
+
+    it("should not copy a filtered file", async () => {
+      mockStat.mockResolvedValueOnce({
+        isFile: () => true,
+        isDirectory: () => false,
+      });
+      await fileSystem.copy("src/file.js", "dest/file.js", {
+        filter: (src) => src !== "src/file.js",
+      });
+      expect(mockCopyFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("pathExists", () => {
+    it("should return true if the path exists", async () => {
+      mockAccess.mockResolvedValueOnce(undefined);
+      const exists = await fileSystem.pathExists("path/to/file");
+      expect(mockAccess).toHaveBeenCalledWith("path/to/file");
+      expect(exists).toBe(true);
+    });
+
+    it("should return false if the path does not exist", async () => {
+      mockAccess.mockRejectedValueOnce(new Error("Path does not exist"));
+      const exists = await fileSystem.pathExists("path/to/file");
+      expect(mockAccess).toHaveBeenCalledWith("path/to/file");
+      expect(exists).toBe(false);
+    });
+  });
+
+  describe("stat", () => {
+    it("should return stat information for a file", async () => {
+      const mockStats = {
+        isFile: () => true,
+        isDirectory: () => false,
+      };
+      mockStat.mockResolvedValueOnce(mockStats);
+      const stats = await fileSystem.stat("path/to/file");
+      expect(mockStat).toHaveBeenCalledWith("path/to/file");
+      expect(stats).toEqual(mockStats);
+    });
+
+    it("should throw an error if the path does not exist", async () => {
+      const statError = new Error("No such file or directory");
+      mockStat.mockRejectedValueOnce(statError);
+      await expect(fileSystem.stat("path/to/file")).rejects.toThrow(statError);
+    });
+  });
+
+  describe("ensureDir", () => {
+    it("should create a new directory and resolve", async () => {
+      mockMkdir.mockResolvedValueOnce(undefined);
+      await expect(
+        fileSystem.ensureDir("path/to/new/dir"),
+      ).resolves.toBeUndefined();
+      expect(mockMkdir).toHaveBeenCalledWith("path/to/new/dir", {
+        recursive: true,
+      });
+    });
+
+    it("should not throw an error if the directory already exists", async () => {
+      mockMkdir.mockResolvedValueOnce(undefined);
+      await expect(
+        fileSystem.ensureDir("path/to/existing/dir"),
+      ).resolves.toBeUndefined();
+      expect(mockMkdir).toHaveBeenCalledWith("path/to/existing/dir", {
+        recursive: true,
+      });
+    });
+
+    it("should throw an error for a permission issue", async () => {
+      const permissionError = new Error(
+        "EACCES: permission denied, mkdir 'path/to/dir'",
+      );
+      mockMkdir.mockRejectedValueOnce(permissionError);
+      await expect(fileSystem.ensureDir("path/to/dir")).rejects.toThrow(
+        permissionError,
+      );
+      expect(mockMkdir).toHaveBeenCalledWith("path/to/dir", {
+        recursive: true,
+      });
+    });
+  });
+
+  describe("remove", () => {
+    it("should call rm with recursive and force options", async () => {
+      await fileSystem.remove("path/to/remove");
+      expect(mockRm).toHaveBeenCalledWith("path/to/remove", {
+        recursive: true,
+        force: true,
+      });
+    });
+  });
+
+  describe("writeFile", () => {
+    it("should call writeJson to write data to a file", async () => {
+      mockWriteFile.mockResolvedValueOnce(null);
+      const data = { key: "value" };
+      await fileSystem.writeFile("path/to/file.json", data);
+
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        "path/to/file.json",
+        JSON.stringify(data, null, 2),
+      );
+    });
+
+    it("should throw an error if writeJson fails", async () => {
+      const writeError = new Error("Permission denied");
+      const data = { key: "value" };
+
+      await expect(
+        fileSystem.writeFile("path/to/file.json", data),
+      ).rejects.toThrow(writeError);
+
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        "path/to/file.json",
+        JSON.stringify(data, null, 2),
+      );
+    });
+  });
+});

--- a/packages/devkit/__tests__/units/utils/files/findUp.spec.ts
+++ b/packages/devkit/__tests__/units/utils/files/findUp.spec.ts
@@ -7,11 +7,9 @@ const { mockFsStat } = vi.hoisted(() => ({
   mockFsStat: vi.fn(),
 }));
 
-vi.mock("fs-extra", () => ({
+vi.mock("#utils/fileSystem.js", () => ({
   default: {
-    promises: {
-      stat: mockFsStat,
-    },
+    stat: mockFsStat,
   },
 }));
 

--- a/packages/devkit/__tests__/units/utils/files/finder.spec.ts
+++ b/packages/devkit/__tests__/units/utils/files/finder.spec.ts
@@ -24,7 +24,7 @@ vi.mock("../../../../src/utils/files/find-up.js", () => ({
   findUp: mockFindUp,
 }));
 
-vi.mock("fs-extra", () => ({
+vi.mock("#utils/fileSystem.js", () => ({
   default: {
     readJson: mockFs.readJson,
     pathExists: mockFs.pathExists,

--- a/packages/devkit/__tests__/units/utils/internationalization/translation-loader.spec.ts
+++ b/packages/devkit/__tests__/units/utils/internationalization/translation-loader.spec.ts
@@ -14,7 +14,7 @@ const { mockFs, mockOsLocale, mockFindLocalesDir } = vi.hoisted(() => ({
   mockFindLocalesDir: vi.fn(),
 }));
 
-vi.mock("fs-extra", () => ({
+vi.mock("#utils/fileSystem.js", () => ({
   default: mockFs,
 }));
 
@@ -47,9 +47,7 @@ describe("loadTranslations", () => {
 
     await loadTranslations("fr");
 
-    expect(mockFs.readJson).toHaveBeenCalledWith(mockFrJsonPath, {
-      encoding: "utf-8",
-    });
+    expect(mockFs.readJson).toHaveBeenCalledWith(mockFrJsonPath);
     expect(translations).toEqual({ "test.key": "Bonjour" });
   });
 
@@ -64,14 +62,12 @@ describe("loadTranslations", () => {
 
     await loadTranslations(null);
 
-    expect(mockFs.readJson).toHaveBeenCalledWith(mockFrJsonPath, {
-      encoding: "utf-8",
-    });
+    expect(mockFs.readJson).toHaveBeenCalledWith(mockFrJsonPath);
     expect(translations).toEqual({ "test.key": "Bonjour" });
   });
 
   it("should fall back to 'en' if the system locale is not supported", async () => {
-    mockOsLocale.mockResolvedValue("es-ES"); // Unsupported locale
+    mockOsLocale.mockResolvedValue("es-ES");
     mockFs.readJson.mockImplementation(async (filePath) => {
       if (filePath === mockEnJsonPath) {
         return { "test.key": "Hello" };
@@ -81,9 +77,7 @@ describe("loadTranslations", () => {
 
     await loadTranslations(null);
 
-    expect(mockFs.readJson).toHaveBeenCalledWith(mockEnJsonPath, {
-      encoding: "utf-8",
-    });
+    expect(mockFs.readJson).toHaveBeenCalledWith(mockEnJsonPath);
     expect(translations).toEqual({ "test.key": "Hello" });
   });
 
@@ -98,9 +92,7 @@ describe("loadTranslations", () => {
 
     await loadTranslations(null);
 
-    expect(mockFs.readJson).toHaveBeenCalledWith(mockEnJsonPath, {
-      encoding: "utf-8",
-    });
+    expect(mockFs.readJson).toHaveBeenCalledWith(mockEnJsonPath);
     expect(translations).toEqual({ "test.key": "Hello" });
   });
 
@@ -118,12 +110,8 @@ describe("loadTranslations", () => {
 
     await loadTranslations("fr");
 
-    expect(mockFs.readJson).toHaveBeenCalledWith(mockFrJsonPath, {
-      encoding: "utf-8",
-    });
-    expect(mockFs.readJson).toHaveBeenCalledWith(mockEnJsonPath, {
-      encoding: "utf-8",
-    });
+    expect(mockFs.readJson).toHaveBeenCalledWith(mockFrJsonPath);
+    expect(mockFs.readJson).toHaveBeenCalledWith(mockEnJsonPath);
     expect(translations).toEqual({ "test.key": "Hello" });
   });
 

--- a/packages/devkit/__tests__/units/utils/project.spec.ts
+++ b/packages/devkit/__tests__/units/utils/project.spec.ts
@@ -6,7 +6,9 @@ const { mockFindPackageRoot, mockFsReadJson } = vi.hoisted(() => ({
   mockFsReadJson: vi.fn(),
 }));
 
-vi.mock("fs-extra", () => ({ default: { readJson: mockFsReadJson } }));
+vi.mock("#utils/fileSystem.js", () => ({
+  default: { readJson: mockFsReadJson },
+}));
 
 vi.mock("#utils/files/finder.js", () => ({
   findPackageRoot: mockFindPackageRoot,

--- a/packages/devkit/__tests__/units/utils/template-utils.spec.ts
+++ b/packages/devkit/__tests__/units/utils/template-utils.spec.ts
@@ -3,7 +3,7 @@ import { vi, describe, it, expect } from "vitest";
 const { mockFsCopy } = vi.hoisted(() => ({
   mockFsCopy: vi.fn(),
 }));
-vi.mock("fs-extra", () => ({ default: { copy: mockFsCopy } }));
+vi.mock("#utils/fileSystem.js", () => ({ default: { copy: mockFsCopy } }));
 
 import {
   copyJavascriptTemplate,

--- a/packages/devkit/__tests__/units/utils/update-project-name.spec.ts
+++ b/packages/devkit/__tests__/units/utils/update-project-name.spec.ts
@@ -6,7 +6,7 @@ const { mockExistsSync, mockReadJson, mockWriteJson } = vi.hoisted(() => ({
   mockWriteJson: vi.fn(),
 }));
 
-vi.mock("fs-extra", () => ({
+vi.mock("#utils/fileSystem.js", () => ({
   default: {
     existsSync: mockExistsSync,
     readJson: mockReadJson,
@@ -49,11 +49,10 @@ describe("update-project-name.ts", () => {
       expect(mockReadJson).toHaveBeenCalledWith(packageJsonPath);
 
       expect(mockWriteJson).toHaveBeenCalledOnce();
-      expect(mockWriteJson).toHaveBeenCalledWith(
-        packageJsonPath,
-        { ...mockPackageJson, name: newProjectName },
-        { spaces: 2 },
-      );
+      expect(mockWriteJson).toHaveBeenCalledWith(packageJsonPath, {
+        ...mockPackageJson,
+        name: newProjectName,
+      });
       expect(mockConsoleError).not.toHaveBeenCalled();
     });
 
@@ -84,11 +83,10 @@ describe("update-project-name.ts", () => {
       expect(mockReadJson).toHaveBeenCalledWith(packageJsonPath);
 
       expect(mockWriteJson).toHaveBeenCalledOnce();
-      expect(mockWriteJson).toHaveBeenCalledWith(
-        packageJsonPath,
-        { ...mockPackageJson, name: newProjectName },
-        { spaces: 2 },
-      );
+      expect(mockWriteJson).toHaveBeenCalledWith(packageJsonPath, {
+        ...mockPackageJson,
+        name: newProjectName,
+      });
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.any(String),
         writeError,

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -51,8 +51,9 @@
     "README.md"
   ],
   "scripts": {
-    "build": "esbuild src/main.ts --bundle --platform=node --outfile=dist/bundle.js --format=esm --external:node:* --external:commander",
-    "build:watch": "esbuild src/main.ts --bundle --platform=node --outfile=dist/bundle.js --format=esm --watch --external:node:* --external:commander",
+    "prepare": "husky",
+    "build": "rollup -c",
+    "build:watch": "rollup -c --watch",
     "type-check": "tsc --noEmit",
     "test:coverage": "vitest run --coverage",
     "test:unit": "vitest",
@@ -71,21 +72,23 @@
     "#commands/*": "./dist/commands/*"
   },
   "dependencies": {
+    "@inquirer/prompts": "^7.8.4",
     "chalk": "^5.5.0",
     "commander": "^14.0.0",
     "deepmerge": "^4.3.1",
     "execa": "^9.6.0",
-    "fs-extra": "^11.3.1",
     "ora": "^8.2.0",
-    "os-locale": "^6.0.2",
-    "prompts": "^2.4.2"
+    "os-locale": "^6.0.2"
   },
   "devDependencies": {
-    "@types/fs-extra": "^11.0.4",
-    "@types/prompts": "^2.4.9",
+    "@rollup/plugin-commonjs": "^28.0.6",
+    "@rollup/plugin-json": "^6.1.0",
+    "@rollup/plugin-node-resolve": "^16.0.1",
+    "@rollup/plugin-typescript": "^12.1.4",
+    "@types/inquirer": "^9.0.9",
     "@vitest/coverage-v8": "^3.2.4",
     "cpx": "^1.5.0",
-    "esbuild": "^0.25.9",
+    "rollup": "^4.50.1",
     "typescript": "^5.0.0",
     "vitest": "^3.2.4"
   }

--- a/packages/devkit/rollup.config.js
+++ b/packages/devkit/rollup.config.js
@@ -1,0 +1,29 @@
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
+import typescript from "@rollup/plugin-typescript";
+import json from "@rollup/plugin-json";
+
+export default {
+  input: "src/main.ts",
+  output: {
+    file: "dist/bundle.js",
+    format: "esm",
+  },
+  plugins: [
+    json(),
+    nodeResolve({ preferBuiltins: true }),
+    commonjs(),
+    typescript({
+      tsconfig: "./tsconfig.json",
+    }),
+  ],
+  external: [
+    "path",
+    "fs",
+    "os",
+    "tty",
+    "readline",
+    "commander",
+    "@inquirer/prompts",
+  ],
+};

--- a/packages/devkit/src/commands/init.ts
+++ b/packages/devkit/src/commands/init.ts
@@ -5,61 +5,55 @@ import {
 } from "#utils/configs/schema.js";
 import { t } from "#utils/internationalization/i18n.js";
 import { ConfigError } from "#utils/errors/base.js";
-import fs from "fs-extra";
+import fs from "#utils/fileSystem.js";
 import path from "path";
 import os from "os";
 import ora, { type Ora } from "ora";
 import chalk from "chalk";
-import prompts from "prompts";
+import { select } from "@inquirer/prompts";
 import { findGlobalConfigFile, findMonorepoRoot } from "#utils/files/finder.js";
 import { findUp } from "#utils/files/find-up.js";
 import { saveConfig } from "#utils/configs/writer.js";
 import { handleErrorAndExit } from "#utils/errors/handler.js";
 
 async function promptForStandardOverwrite(filePath: string): Promise<boolean> {
-  const response = await prompts({
-    type: "select",
-    name: "overwrite",
+  const response = await select({
     message: chalk.yellow(
       t("config.init.confirm_overwrite", { path: filePath }),
     ),
     choices: [
-      { title: t("common.yes"), value: true },
-      { title: t("common.no"), value: false },
+      { name: t("common.yes"), value: true },
+      { name: t("common.no"), value: false },
     ],
-    initial: 0,
+    default: true,
   });
-  return response.overwrite;
+  return response;
 }
 
 async function promptForMonorepoOverwrite(filePath: string): Promise<boolean> {
-  const response = await prompts({
-    type: "select",
-    name: "overwrite",
+  const response = await select({
     message: chalk.yellow(
       t("config.init.confirm_monorepo_overwrite", { path: filePath }),
     ),
     choices: [
-      { title: t("common.yes"), value: true },
-      { title: t("common.no"), value: false },
+      { name: t("common.yes"), value: true },
+      { name: t("common.no"), value: false },
     ],
-    initial: 0,
+    default: true,
   });
-  return response.overwrite;
+  return response;
 }
 
 async function promptForMonorepoLocation(): Promise<string> {
-  const response = await prompts({
-    type: "select",
-    name: "location",
+  const response = await select({
     message: chalk.yellow(t("config.init.monorepo_location")),
     choices: [
-      { title: t("config.init.location_current"), value: "local" },
-      { title: t("config.init.location_root"), value: "root" },
+      { name: t("config.init.location_current"), value: "local" },
+      { name: t("config.init.location_root"), value: "root" },
     ],
-    initial: 0,
+    default: "local",
   });
-  return response.location;
+  return response;
 }
 
 async function handleGlobalInit(spinner: Ora) {

--- a/packages/devkit/src/utils/cache/fs-manager.ts
+++ b/packages/devkit/src/utils/cache/fs-manager.ts
@@ -1,8 +1,8 @@
-import fs from "fs-extra";
+import fs from "#utils/fileSystem.js";
 
 export async function doesRepoExist(repoPath: string): Promise<boolean> {
   try {
-    await fs.promises.stat(repoPath);
+    await fs.stat(repoPath);
     return true;
   } catch {
     return false;

--- a/packages/devkit/src/utils/cache/git.ts
+++ b/packages/devkit/src/utils/cache/git.ts
@@ -1,7 +1,7 @@
 import { execa } from "execa";
 import { t } from "#utils/internationalization/i18n.js";
 import { GitError } from "#utils/errors/base.js";
-import fs from "fs-extra";
+import fs from "#utils/fileSystem.js";
 import path from "path";
 
 export function getRepoNameFromUrl(url: string): string {
@@ -44,7 +44,7 @@ export async function isRepoFresh(
     return false;
   }
   try {
-    const stat = await fs.promises.stat(path.join(repoPath, ".git/FETCH_HEAD"));
+    const stat = await fs.stat(path.join(repoPath, ".git/FETCH_HEAD"));
     const oneDayInMs = 24 * 60 * 60 * 1000;
     return Date.now() - stat.mtime.getTime() < oneDayInMs;
   } catch {

--- a/packages/devkit/src/utils/configs/loader.ts
+++ b/packages/devkit/src/utils/configs/loader.ts
@@ -1,6 +1,6 @@
 import deepmerge from "deepmerge";
 import type { Ora } from "ora";
-import fs from "fs-extra";
+import fs from "#utils/fileSystem.js";
 import {
   type CliConfig,
   CONFIG_FILE_NAMES,

--- a/packages/devkit/src/utils/configs/reader.ts
+++ b/packages/devkit/src/utils/configs/reader.ts
@@ -1,7 +1,9 @@
-import { existsSync } from "fs-extra";
+import fs from "#utils/fileSystem.js";
 import { readFile } from "fs/promises";
 import { type CliConfig } from "#utils/configs/schema.js";
 import { getConfigFilepath } from "#utils/configs/path-finder.js";
+
+const { existsSync } = fs;
 
 export async function readConfigAtPath(
   filePath: string,

--- a/packages/devkit/src/utils/configs/writer.ts
+++ b/packages/devkit/src/utils/configs/writer.ts
@@ -1,4 +1,4 @@
-import fs from "fs-extra";
+import fs from "#utils/fileSystem.js";
 import { DevkitError, ConfigError } from "../errors/base.js";
 import { t } from "#utils/internationalization/i18n.js";
 import { getConfigFilepath } from "./path-finder.js";
@@ -6,7 +6,7 @@ import { type CliConfig, type CacheStrategy } from "./schema.js";
 
 export async function saveConfig(config: CliConfig, filePath: string) {
   try {
-    await fs.writeJson(filePath, config, { spaces: 2 });
+    await fs.writeJson(filePath, config);
   } catch (error) {
     throw new DevkitError(t("error.config.save", { file: filePath }), {
       cause: error,

--- a/packages/devkit/src/utils/fileSystem.ts
+++ b/packages/devkit/src/utils/fileSystem.ts
@@ -1,0 +1,87 @@
+import {
+  promises as fsPromises,
+  existsSync as fsExistsSync,
+  type Stats,
+} from "fs";
+import path from "path";
+
+async function readJson(filePath: string): Promise<any> {
+  const fileContent = await fsPromises.readFile(filePath, {
+    encoding: "utf8",
+  });
+  return JSON.parse(fileContent);
+}
+
+async function writeJson<T>(filePath: string, data: T): Promise<void> {
+  const jsonString = JSON.stringify(data, null, 2);
+  await fsPromises.writeFile(filePath, jsonString);
+}
+
+const existsSync = fsExistsSync;
+
+async function copy(
+  source: string,
+  destination: string,
+  options: {
+    filter?: (src: string) => boolean;
+  } = {},
+): Promise<void> {
+  const filterFunction = options.filter || (() => true);
+
+  const stats = await fsPromises.stat(source);
+
+  if (stats.isDirectory()) {
+    if (!filterFunction(source)) {
+      return;
+    }
+
+    await fsPromises.mkdir(destination, { recursive: true });
+    const entries = await fsPromises.readdir(source);
+
+    for (const entry of entries) {
+      const srcPath = path.join(source, entry);
+      const destPath = path.join(destination, entry);
+      await copy(srcPath, destPath, options);
+    }
+  } else if (stats.isFile()) {
+    if (!filterFunction(source)) {
+      return;
+    }
+    await fsPromises.copyFile(source, destination);
+  }
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fsPromises.access(filePath);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+async function stat(filePath: string): Promise<Stats> {
+  return await fsPromises.stat(filePath);
+}
+
+async function ensureDir(dirPath: string): Promise<void> {
+  await fsPromises.mkdir(dirPath, { recursive: true });
+}
+
+async function remove(path: string): Promise<void> {
+  await fsPromises.rm(path, { recursive: true, force: true });
+}
+
+const writeFile = writeJson;
+
+export default {
+  readJson,
+  writeJson,
+  existsSync,
+  copy,
+  pathExists,
+  stat,
+  ensureDir,
+  remove,
+  writeFile,
+};

--- a/packages/devkit/src/utils/files/find-up.ts
+++ b/packages/devkit/src/utils/files/find-up.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import fs from "fs-extra";
+import fs from "#utils/fileSystem.js";
 import { homedir } from "os";
 
 export async function findUp(
@@ -13,7 +13,7 @@ export async function findUp(
     for (const file of filesToFind) {
       const filePath = path.join(currentDir, file);
       try {
-        await fs.promises.stat(filePath);
+        await fs.stat(filePath);
         return filePath;
       } catch (e) {
         // File does not exist, continue search

--- a/packages/devkit/src/utils/files/finder.ts
+++ b/packages/devkit/src/utils/files/finder.ts
@@ -2,7 +2,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { dirname } from "path";
 import os from "os";
-import fs from "fs-extra";
+import fs from "#utils/fileSystem.js";
 import { CONFIG_FILE_NAMES, FILE_NAMES } from "#utils/configs/schema.js";
 import { DevkitError } from "#utils/errors/base.js";
 import { findUp } from "./find-up.js";

--- a/packages/devkit/src/utils/internationalization/translation-loader.ts
+++ b/packages/devkit/src/utils/internationalization/translation-loader.ts
@@ -1,4 +1,4 @@
-import fs from "fs-extra";
+import fs from "#utils/fileSystem.js";
 import path from "path";
 import { osLocale } from "os-locale";
 import {
@@ -35,12 +35,12 @@ export async function loadTranslations(
     const localesDir = await findLocalesDir();
     const filePath = path.join(localesDir, `${languageToLoad}.json`);
 
-    translations = await fs.readJson(filePath, { encoding: "utf-8" });
+    translations = await fs.readJson(filePath);
   } catch (error) {
     const localesDir = await findLocalesDir();
     const fallbackPath = path.join(localesDir, "en.json");
     try {
-      translations = await fs.readJson(fallbackPath, { encoding: "utf-8" });
+      translations = await fs.readJson(fallbackPath);
     } catch (e) {
       throw new DevkitError(
         `Failed to load translations from both ${languageToLoad}.json and the fallback en.json`,

--- a/packages/devkit/src/utils/project.ts
+++ b/packages/devkit/src/utils/project.ts
@@ -1,4 +1,4 @@
-import fs from "fs-extra";
+import fs from "#utils/fileSystem.js";
 import path from "path";
 import { findPackageRoot } from "#utils/files/finder.js";
 import { t } from "#utils/internationalization/i18n.js";

--- a/packages/devkit/src/utils/template-utils.ts
+++ b/packages/devkit/src/utils/template-utils.ts
@@ -1,8 +1,8 @@
-import fs from "fs-extra";
 import {
   FILE_NAMES,
   type SupportedProgrammingLanguageValues,
 } from "./configs/schema.js";
+import fs from "#utils/fileSystem.js";
 
 export function getFilesToFilter(
   language: SupportedProgrammingLanguageValues,

--- a/packages/devkit/src/utils/update-project-name.ts
+++ b/packages/devkit/src/utils/update-project-name.ts
@@ -1,4 +1,4 @@
-import fs from "fs-extra";
+import fs from "#utils/fileSystem.js";
 import path from "path";
 import { FILE_NAMES } from "./configs/schema.js";
 import { t } from "#utils/internationalization/i18n.js";
@@ -19,7 +19,7 @@ export async function updateJavascriptProjectName(
     const packageJson = await fs.readJson(packageJsonPath);
     packageJson.name = newProjectName;
 
-    await fs.writeJson(packageJsonPath, packageJson, { spaces: 2 });
+    await fs.writeJson(packageJsonPath, packageJson);
   } catch (error) {
     console.error(
       chalk.red(t("error.package.failed_to_update_project_name")),
@@ -27,4 +27,3 @@ export async function updateJavascriptProjectName(
     );
   }
 }
-//


### PR DESCRIPTION
## Description

This pull request addresses and resolves several key issues by migrating the build process from `esbuild` to `Rollup`.

The primary change is a complete overhaul of the build pipeline, which was necessary to fix the recurring `Dynamic require of "..." is not supported` bug. The new Rollup-based build correctly handles Node.js built-in modules and CommonJS dependencies, ensuring a stable and reliable build.

The changes also include:
* Adding the necessary Rollup plugins (`@rollup/plugin-commonjs`, `@rollup/plugin-node-resolve`, `@rollup/plugin-typescript`, `@rollup/plugin-json`).
* Refining the Rollup configuration to correctly handle external Node.js modules and JSON files.
* Updating the `package.json` build scripts to use the new `rollup -c` command.
* Making the integration tests for the CLI's output more resilient to ensure they pass correctly by normalizing whitespace and using regular expressions.
* Updating the `README.md` with new usage instructions for global installation and correcting Markdown formatting errors.

Fixes # (Build process bug)

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

---

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing feature support current supported languages
- [x] Any dependent changes have been merged and published in downstream modules