### PR TITLE
fix: add locales to dist file on build

### DIFF
--- a/.changeset/short-birds-live.md
+++ b/.changeset/short-birds-live.md
@@ -1,0 +1,5 @@
+---
+"scaffolder-toolkit": patch
+---
+
+Fix missing locales on build

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "packages/devkit": {
       "name": "scaffolder-toolkit",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "bin": {
         "devkit": "./dist/bundle.js",
         "dk": "./dist/bundle.js",
@@ -37,9 +37,11 @@
         "@rollup/plugin-node-resolve": "^16.0.1",
         "@rollup/plugin-typescript": "^12.1.4",
         "@types/inquirer": "^9.0.9",
+        "@types/minimatch": "^6.0.0",
         "@vitest/coverage-v8": "^3.2.4",
         "cpx": "^1.5.0",
         "rollup": "^4.50.1",
+        "rollup-plugin-copy": "^3.5.0",
         "typescript": "^5.0.0",
         "vitest": "^3.2.4",
       },
@@ -318,7 +320,13 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
+    "@types/fs-extra": ["@types/fs-extra@8.1.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ=="],
+
+    "@types/glob": ["@types/glob@7.2.0", "", { "dependencies": { "@types/minimatch": "*", "@types/node": "*" } }, "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA=="],
+
     "@types/inquirer": ["@types/inquirer@9.0.9", "", { "dependencies": { "@types/through": "*", "rxjs": "^7.2.0" } }, "sha512-/mWx5136gts2Z2e5izdoRCo46lPp5TMs9R15GTSsgg/XnZyxDWVqoVU3R9lWnccKpqwsJLvRoxbCjoJtZB7DSw=="],
+
+    "@types/minimatch": ["@types/minimatch@6.0.0", "", { "dependencies": { "minimatch": "*" } }, "sha512-zmPitbQ8+6zNutpwgcQuLcsEpn/Cj54Kbn7L5pX0Os5kdWplB7xPgEh/g+SWOB/qmows2gpuCaPyduq8ZZRnxA=="],
 
     "@types/node": ["@types/node@24.3.1", "", { "dependencies": { "undici-types": "~7.10.0" } }, "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g=="],
 
@@ -394,7 +402,7 @@
 
     "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
 
-    "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+    "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -436,7 +444,7 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
-    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+    "colorette": ["colorette@1.4.0", "", {}, "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="],
 
     "commander": ["commander@14.0.0", "", {}, "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA=="],
 
@@ -586,7 +594,7 @@
 
     "global-directory": ["global-directory@4.0.1", "", { "dependencies": { "ini": "4.1.1" } }, "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q=="],
 
-    "globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
+    "globby": ["globby@10.0.1", "", { "dependencies": { "@types/glob": "^7.1.1", "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.0.3", "glob": "^7.1.3", "ignore": "^5.1.1", "merge2": "^1.2.3", "slash": "^3.0.0" } }, "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
@@ -658,7 +666,7 @@
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
-    "is-plain-object": ["is-plain-object@2.0.4", "", { "dependencies": { "isobject": "^3.0.1" } }, "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og=="],
+    "is-plain-object": ["is-plain-object@3.0.1", "", {}, "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g=="],
 
     "is-posix-bracket": ["is-posix-bracket@0.1.1", "", {}, "sha512-Yu68oeXJ7LeWNmZ3Zov/xg/oDBnBK2RNxwYY1ilNJX+tKKZqgPK+qOn/Gs9jEu66KDY9Netf5XLKNGzas/vPfQ=="],
 
@@ -766,7 +774,7 @@
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
-    "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+    "minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
@@ -917,6 +925,8 @@
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
     "rollup": ["rollup@4.50.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.50.1", "@rollup/rollup-android-arm64": "4.50.1", "@rollup/rollup-darwin-arm64": "4.50.1", "@rollup/rollup-darwin-x64": "4.50.1", "@rollup/rollup-freebsd-arm64": "4.50.1", "@rollup/rollup-freebsd-x64": "4.50.1", "@rollup/rollup-linux-arm-gnueabihf": "4.50.1", "@rollup/rollup-linux-arm-musleabihf": "4.50.1", "@rollup/rollup-linux-arm64-gnu": "4.50.1", "@rollup/rollup-linux-arm64-musl": "4.50.1", "@rollup/rollup-linux-loongarch64-gnu": "4.50.1", "@rollup/rollup-linux-ppc64-gnu": "4.50.1", "@rollup/rollup-linux-riscv64-gnu": "4.50.1", "@rollup/rollup-linux-riscv64-musl": "4.50.1", "@rollup/rollup-linux-s390x-gnu": "4.50.1", "@rollup/rollup-linux-x64-gnu": "4.50.1", "@rollup/rollup-linux-x64-musl": "4.50.1", "@rollup/rollup-openharmony-arm64": "4.50.1", "@rollup/rollup-win32-arm64-msvc": "4.50.1", "@rollup/rollup-win32-ia32-msvc": "4.50.1", "@rollup/rollup-win32-x64-msvc": "4.50.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-78E9voJHwnXQMiQdiqswVLZwJIzdBKJ1GdI5Zx6XwoFKUIk09/sSrr+05QFzvYb8q6Y9pPV45zzDuYa3907TZA=="],
+
+    "rollup-plugin-copy": ["rollup-plugin-copy@3.5.0", "", { "dependencies": { "@types/fs-extra": "^8.0.1", "colorette": "^1.1.0", "fs-extra": "^8.1.0", "globby": "10.0.1", "is-plain-object": "^3.0.0" } }, "sha512-wI8D5dvYovRMx/YYKtUNt3Yxaw4ORC9xo6Gt9t22kveWz1enG9QrhVlagzwrxSC455xD1dHMKhIJkbsQ7d48BA=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
@@ -1102,6 +1112,8 @@
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
+    "@manypkg/get-packages/globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
+
     "@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "anymatch/micromatch": ["micromatch@2.3.11", "", { "dependencies": { "arr-diff": "^2.0.0", "array-unique": "^0.2.1", "braces": "^1.8.2", "expand-brackets": "^0.1.4", "extglob": "^0.3.1", "filename-regex": "^2.0.0", "is-extglob": "^1.0.0", "is-glob": "^2.0.1", "kind-of": "^3.0.2", "normalize-path": "^2.0.1", "object.omit": "^2.0.0", "parse-glob": "^3.0.4", "regex-cache": "^0.4.2" } }, "sha512-LnU2XFEk9xxSJ6rfgAry/ty5qwUTyHYOBU0g4R6tIw5ljwgGIBmiKhRWLw5NpMOnrgUNcDJ4WMp8rl3sYVHLNA=="],
@@ -1122,6 +1134,8 @@
 
     "cosmiconfig/js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
 
+    "cpx/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
     "enquirer/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "expand-range/fill-range": ["fill-range@2.2.4", "", { "dependencies": { "is-number": "^2.1.0", "isobject": "^2.0.0", "randomatic": "^3.0.0", "repeat-element": "^1.1.2", "repeat-string": "^1.5.2" } }, "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q=="],
@@ -1130,11 +1144,15 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
     "has-values/is-number": ["is-number@3.0.0", "", { "dependencies": { "kind-of": "^3.0.2" } }, "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg=="],
 
     "has-values/kind-of": ["kind-of@4.0.0", "", { "dependencies": { "is-buffer": "^1.1.5" } }, "sha512-24XsCxmEbRwEDbz/qz3stgin8TTzZ1ESR56OMCN0ujYg+vRutNSiOj9bHH9u85DKgXguraugV5sFuvbD4FW/hw=="],
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "listr2/colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
@@ -1164,7 +1182,11 @@
 
     "readdirp/micromatch": ["micromatch@3.1.10", "", { "dependencies": { "arr-diff": "^4.0.0", "array-unique": "^0.3.2", "braces": "^2.3.1", "define-property": "^2.0.2", "extend-shallow": "^3.0.2", "extglob": "^2.0.4", "fragment-cache": "^0.2.1", "kind-of": "^6.0.2", "nanomatch": "^1.2.9", "object.pick": "^1.3.0", "regex-not": "^1.0.0", "snapdragon": "^0.8.1", "to-regex": "^3.0.2" } }, "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg=="],
 
+    "rollup-plugin-copy/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
+
     "set-value/extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
+
+    "set-value/is-plain-object": ["is-plain-object@2.0.4", "", { "dependencies": { "isobject": "^3.0.1" } }, "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og=="],
 
     "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@4.0.0", "", {}, "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="],
 
@@ -1187,8 +1209,6 @@
     "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "test-exclude/glob": ["glob@10.4.5", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg=="],
-
-    "test-exclude/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "unset-value/has-value": ["has-value@0.3.1", "", { "dependencies": { "get-value": "^2.0.3", "has-values": "^0.1.4", "isobject": "^2.0.0" } }, "sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q=="],
 
@@ -1228,17 +1248,25 @@
 
     "cosmiconfig/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
+    "cpx/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
     "enquirer/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "expand-range/fill-range/is-number": ["is-number@2.1.0", "", { "dependencies": { "kind-of": "^3.0.2" } }, "sha512-QUzH43Gfb9+5yckcrSA0VBDwEtDUchrk4F6tfJZQuNzDJbEDB9cZNzSfXGQ1jqmdDY/kl41lUOWM9syA8z8jlg=="],
 
     "expand-range/fill-range/isobject": ["isobject@2.1.0", "", { "dependencies": { "isarray": "1.0.0" } }, "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA=="],
 
+    "extend-shallow/is-extendable/is-plain-object": ["is-plain-object@2.0.4", "", { "dependencies": { "isobject": "^3.0.1" } }, "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og=="],
+
     "fast-glob/glob-parent/is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "has-values/is-number/kind-of": ["kind-of@3.2.2", "", { "dependencies": { "is-buffer": "^1.1.5" } }, "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ=="],
 
     "log-update/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+
+    "mixin-deep/is-extendable/is-plain-object": ["is-plain-object@2.0.4", "", { "dependencies": { "isobject": "^3.0.1" } }, "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og=="],
 
     "object-copy/define-property/is-descriptor": ["is-descriptor@0.1.7", "", { "dependencies": { "is-accessor-descriptor": "^1.0.1", "is-data-descriptor": "^1.0.1" } }, "sha512-C3grZTvObeN1xud4cRWl366OMXZTj0+HGyk4hvfpx4ZHt1Pb60ANSXqCK7pdOTeUQpRzECBSTphqvD7U+l22Eg=="],
 
@@ -1259,8 +1287,6 @@
     "static-extend/define-property/is-descriptor": ["is-descriptor@0.1.7", "", { "dependencies": { "is-accessor-descriptor": "^1.0.1", "is-data-descriptor": "^1.0.1" } }, "sha512-C3grZTvObeN1xud4cRWl366OMXZTj0+HGyk4hvfpx4ZHt1Pb60ANSXqCK7pdOTeUQpRzECBSTphqvD7U+l22Eg=="],
 
     "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "test-exclude/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "unset-value/has-value/has-values": ["has-values@0.1.4", "", {}, "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ=="],
 

--- a/packages/devkit/__tests__/integrations/configs.spec.ts
+++ b/packages/devkit/__tests__/integrations/configs.spec.ts
@@ -53,7 +53,7 @@ describe("dk config commands", () => {
       );
 
       expect(exitCode).toBe(0);
-      expect(all).toContain("✅ Configuration updated successfully!");
+      expect(all).toContain("✔ Configuration updated successfully!");
 
       const configContent = await fs.readJson(
         path.join(tempDir, LOCAL_CONFIG_FILE_NAME),
@@ -69,7 +69,7 @@ describe("dk config commands", () => {
       );
 
       expect(exitCode).toBe(0);
-      expect(all).toContain("✅ Configuration updated successfully!");
+      expect(all).toContain("✔ Configuration updated successfully!");
 
       const configContent = await fs.readJson(
         path.join(tempDir, LOCAL_CONFIG_FILE_NAME),
@@ -97,7 +97,7 @@ describe("dk config commands", () => {
       );
 
       expect(exitCode).toBe(0);
-      expect(all).toContain("✅ Configuration updated successfully!");
+      expect(all).toContain("✔ Configuration updated successfully!");
 
       const globalConfigContent = await fs.readJson(globalConfigPath);
       expect(globalConfigContent.settings.language).toBe("fr");
@@ -162,7 +162,7 @@ describe("dk config commands", () => {
       );
 
       expect(exitCode).toBe(0);
-      expect(all).toContain("✅ Configuration loaded successfully!");
+      expect(all).toContain("✔ Configuration loaded successfully!");
       expect(all).toContain("Using local configuration.");
       expect(all).toContain("language: en");
     });
@@ -175,7 +175,7 @@ describe("dk config commands", () => {
       );
 
       expect(exitCode).toBe(0);
-      expect(all).toContain("✅ Configuration loaded successfully!");
+      expect(all).toContain("✔ Configuration loaded successfully!");
       expect(all).toContain("defaultPackageManager: bun");
     });
 
@@ -200,7 +200,7 @@ describe("dk config commands", () => {
       );
 
       expect(exitCode).toBe(0);
-      expect(all).toContain("✅ Configuration loaded successfully!");
+      expect(all).toContain("✔ Configuration loaded successfully!");
       expect(all).toContain("Using local configuration.");
       expect(all).toContain('"language": "en"');
       expect(all).toContain('"defaultPackageManager": "bun"');
@@ -228,7 +228,7 @@ describe("dk config commands", () => {
       );
 
       expect(exitCode).toBe(0);
-      expect(all).toContain("✅ Configuration loaded successfully!");
+      expect(all).toContain("✔ Configuration loaded successfully!");
       expect(all).toContain("Using global configuration.");
       expect(all).toContain("language: fr");
 
@@ -262,7 +262,7 @@ describe("dk config commands", () => {
       );
 
       expect(exitCode).toBe(0);
-      expect(all).toContain("✅ Configuration loaded successfully!");
+      expect(all).toContain("✔ Configuration loaded successfully!");
       expect(all).toContain(
         "No local configuration file found. Displaying global settings instead.",
       );
@@ -286,7 +286,7 @@ describe("dk config commands", () => {
       );
 
       expect(exitCode).toBe(0);
-      expect(all).toContain("✅ Configuration loaded successfully!");
+      expect(all).toContain("✔ Configuration loaded successfully!");
       expect(all).toContain(
         "No local configuration file found. Displaying default settings instead.",
       );

--- a/packages/devkit/__tests__/integrations/init.spec.ts
+++ b/packages/devkit/__tests__/integrations/init.spec.ts
@@ -46,7 +46,7 @@ describe("dk init", () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(all).toContain("✅ Configuration file created successfully!");
+    expect(all).toContain("✔ Configuration file created successfully!");
     const configPath = path.join(tempDir, LOCAL_CONFIG_FILE_NAME);
     const fileExists = await fs.pathExists(configPath);
     expect(fileExists).toBe(true);
@@ -69,7 +69,7 @@ describe("dk init", () => {
     );
 
     expect(exitCode).toBe(0);
-    expect(all).toContain("✅ Configuration file created successfully!");
+    expect(all).toContain("✔ Configuration file created successfully!");
     const fileExists = await fs.pathExists(globalConfigPath);
     expect(fileExists).toBe(true);
 
@@ -125,7 +125,7 @@ describe("dk init with existing file", () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(all).toContain("✅ Configuration file created successfully!");
+    expect(all).toContain("✔ Configuration file created successfully!");
     const newContent = await fs.readJson(
       path.join(tempDir, LOCAL_CONFIG_FILE_NAME),
     );
@@ -171,7 +171,7 @@ describe("dk init in a monorepo", () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(all).toContain("✅ Configuration file created successfully!");
+    expect(all).toContain("✔ Configuration file created successfully!");
     const rootConfigPath = path.join(tempDir, LOCAL_CONFIG_FILE_NAME);
     const fileExists = await fs.pathExists(rootConfigPath);
     expect(fileExists).toBe(true);
@@ -195,7 +195,7 @@ describe("dk init in a monorepo", () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(all).toContain("✅ Configuration file created successfully!");
+    expect(all).toContain("✔ Configuration file created successfully!");
     const nestedConfigPath = path.join(
       nestedPackagePath,
       LOCAL_CONFIG_FILE_NAME,
@@ -224,7 +224,7 @@ describe("dk init in a monorepo", () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(all).toContain("✅ Configuration file created successfully!");
+    expect(all).toContain("✔ Configuration file created successfully!");
 
     const newContent = await fs.readJson(rootConfigPath);
     expect(newContent).toEqual(defaultCliConfig);
@@ -275,7 +275,7 @@ describe("dk init in a monorepo", () => {
       .trim();
     expect(exitCode).toBe(0);
     expect(cleanedOutput).toContain(
-      "✅ Configuration file created successfully!",
+      "✔ Configuration file created successfully!",
     );
     expect(cleanedOutput).toContain(
       `A config file exists in the monorepo root at ${rootConfigPath}. Do you want to create a new one in the current package?`,

--- a/packages/devkit/__tests__/integrations/list.spec.ts
+++ b/packages/devkit/__tests__/integrations/list.spec.ts
@@ -218,6 +218,6 @@ describe("dk list", () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(all).toContain("✅ No templates found in the configuration file.");
+    expect(all).toContain("✔ No templates found in the configuration file.");
   });
 });

--- a/packages/devkit/__tests__/integrations/remove-template.spec.ts
+++ b/packages/devkit/__tests__/integrations/remove-template.spec.ts
@@ -110,7 +110,7 @@ describe("dk remove-template", () => {
 
     expect(exitCode).toBe(0);
     expect(all).toContain(
-      "✅ Template 'node-api' for 'node' removed successfully!",
+      "✔ Template 'node-api' for 'node' removed successfully!",
     );
     expect(updatedConfig.templates.node.templates["node-api"]).toBeUndefined();
     expect(
@@ -135,7 +135,7 @@ describe("dk remove-template", () => {
 
     expect(exitCode).toBe(0);
     expect(all).toContain(
-      "✅ Template 'rts' for 'javascript' removed successfully!",
+      "✔ Template 'rts' for 'javascript' removed successfully!",
     );
     expect(
       updatedConfig.templates.javascript.templates["react-ts"],
@@ -162,7 +162,7 @@ describe("dk remove-template", () => {
 
     expect(exitCode).toBe(0);
     expect(all).toContain(
-      "✅ Template 'django' for 'python' removed successfully!",
+      "✔ Template 'django' for 'python' removed successfully!",
     );
     expect(updatedConfig.templates.python.templates.django).toBeUndefined();
   });

--- a/packages/devkit/locales/en.json
+++ b/packages/devkit/locales/en.json
@@ -20,7 +20,7 @@
         }
       },
       "scaffolding": "Scaffolding project '{projectName}' with the '{template}' template...",
-      "success": "✅ Project '{projectName}' created successfully!",
+      "success": "✔ Project '{projectName}' created successfully!",
       "fail": "❌ Failed to scaffold project: {error}"
     }
   },
@@ -54,7 +54,7 @@
       "description": "Remove a template from the configuration."
     },
     "start": "Removing template from configuration...",
-    "success": "✅ Template '{templateName}' for '{language}' removed successfully!",
+    "success": "✔ Template '{templateName}' for '{language}' removed successfully!",
     "language": {
       "argument": "The programming language of the template to remove."
     },
@@ -74,22 +74,22 @@
   "scaffolding": {
     "project": {
       "start": "Scaffolding {language} project: {project}",
-      "success": "✅ {language} project '{project}' created successfully!",
+      "success": "✔ {language} project '{project}' created successfully!",
       "fail": "❌ Failed to scaffold {language} project: {error}"
     },
     "copy": {
       "start": "📂 Coping local template files...",
-      "success": "✅ Local template copied successfully!",
+      "success": "✔ Local template copied successfully!",
       "fail": "❌ Failed to copy local template."
     },
     "run": {
       "start": "📦 Running official CLI command: {command}...",
-      "success": "✅ Official CLI command ran successfully!",
+      "success": "✔ Official CLI command ran successfully!",
       "fail": "❌ Failed to run official CLI command."
     },
     "install": {
       "start": "📦 Installing dependencies with {pm}...",
-      "success": "✅ Dependencies installed successfully!",
+      "success": "✔ Dependencies installed successfully!",
       "fail": "❌ Failed to install dependencies."
     },
     "complete": {
@@ -177,8 +177,8 @@
         "global": "Update the template in the global configuration instead of the local one."
       },
       "updating": "Updating template '{templateName}' in configuration...",
-      "success": "✅ Template '{templateName}' updated successfully!",
-      "success_name": "✅ Template '{oldName}' updated to '{newName}' successfully!"
+      "success": "✔ Template '{templateName}' updated successfully!",
+      "success_name": "✔ Template '{oldName}' updated to '{newName}' successfully!"
     },
     "cache": {
       "command": {
@@ -306,12 +306,12 @@
   "cache": {
     "clone": {
       "start": "✨ Cloning new template from {url}...",
-      "success": "✅ Template cloned successfully!",
+      "success": "✔ Template cloned successfully!",
       "fail": "❌ Failed to clone repository."
     },
     "refresh": {
       "start": "🔄 Refreshing cached template...",
-      "success": "✅ Template refreshed successfully!",
+      "success": "✔ Template refreshed successfully!",
       "fail": "❌ Failed to refresh template."
     },
     "use": {
@@ -319,7 +319,7 @@
     },
     "copy": {
       "start": "📂 Coping cached template to project directory...",
-      "success": "✅ Files copied successfully!",
+      "success": "✔ Files copied successfully!",
       "fail": "❌ Failed to copy files from cache."
     }
   },

--- a/packages/devkit/locales/fr.json
+++ b/packages/devkit/locales/fr.json
@@ -20,7 +20,7 @@
         }
       },
       "scaffolding": "Création du projet '{projectName}' avec le modèle '{template}'...",
-      "success": "✅ Projet '{projectName}' créé avec succès !",
+      "success": "✔ Projet '{projectName}' créé avec succès !",
       "fail": "❌ Échec de la création du projet : {error}"
     }
   },
@@ -54,7 +54,7 @@
       "description": "Supprimer un modèle de la configuration."
     },
     "start": "Suppression du modèle de la configuration...",
-    "success": "✅ Modèle '{templateName}' pour '{language}' supprimé avec succès !",
+    "success": "✔ Modèle '{templateName}' pour '{language}' supprimé avec succès !",
     "language": {
       "argument": "Le langage de programmation du modèle à supprimer."
     },
@@ -74,22 +74,22 @@
   "scaffolding": {
     "project": {
       "start": "Création du projet {language} : {project}",
-      "success": "✅ Projet {language} '{project}' créé avec succès !",
+      "success": "✔ Projet {language} '{project}' créé avec succès !",
       "fail": "❌ Échec de la création du projet {language} : {error}"
     },
     "copy": {
       "start": "📂 Copie des fichiers du modèle local...",
-      "success": "✅ Modèle local copié avec succès !",
+      "success": "✔ Modèle local copié avec succès !",
       "fail": "❌ Échec de la copie du modèle local."
     },
     "run": {
       "start": "📦 Exécution de la commande CLI officielle : {command}...",
-      "success": "✅ Commande CLI officielle exécutée avec succès !",
+      "success": "✔ Commande CLI officielle exécutée avec succès !",
       "fail": "❌ Échec de l'exécution de la commande CLI officielle."
     },
     "install": {
       "start": "📦 Installation des dépendances avec {pm}...",
-      "success": "✅ Dépendances installées avec succès !",
+      "success": "✔ Dépendances installées avec succès !",
       "fail": "❌ Échec de l'installation des dépendances."
     },
     "complete": {
@@ -177,8 +177,8 @@
         "global": "Mettre à jour le modèle dans la configuration globale au lieu de la locale."
       },
       "updating": "Mise à jour du modèle '{templateName}' dans la configuration...",
-      "success": "✅ Modèle '{templateName}' mis à jour avec succès !",
-      "success_name": "✅ Modèle '{oldName}' mis à jour en '{newName}' avec succès !"
+      "success": "✔ Modèle '{templateName}' mis à jour avec succès !",
+      "success_name": "✔ Modèle '{oldName}' mis à jour en '{newName}' avec succès !"
     },
     "cache": {
       "command": {
@@ -306,12 +306,12 @@
   "cache": {
     "clone": {
       "start": "✨ Clonage du nouveau modèle depuis {url}...",
-      "success": "✅ Modèle cloné avec succès !",
+      "success": "✔ Modèle cloné avec succès !",
       "fail": "❌ Échec du clonage du dépôt."
     },
     "refresh": {
       "start": "🔄 Actualisation du modèle en cache...",
-      "success": "✅ Modèle actualisé avec succès !",
+      "success": "✔ Modèle actualisé avec succès !",
       "fail": "❌ Échec de l'actualisation du modèle."
     },
     "use": {
@@ -319,7 +319,7 @@
     },
     "copy": {
       "start": "📂 Copie du modèle en cache vers le répertoire du projet...",
-      "success": "✅ Fichiers copiés avec succès !",
+      "success": "✔ Fichiers copiés avec succès !",
       "fail": "❌ Échec de la copie des fichiers depuis le cache."
     }
   },

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -85,9 +85,11 @@
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-typescript": "^12.1.4",
     "@types/inquirer": "^9.0.9",
+    "@types/minimatch": "^6.0.0",
     "@vitest/coverage-v8": "^3.2.4",
     "cpx": "^1.5.0",
     "rollup": "^4.50.1",
+    "rollup-plugin-copy": "^3.5.0",
     "typescript": "^5.0.0",
     "vitest": "^3.2.4"
   }

--- a/packages/devkit/rollup.config.js
+++ b/packages/devkit/rollup.config.js
@@ -2,12 +2,14 @@ import { nodeResolve } from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 import typescript from "@rollup/plugin-typescript";
 import json from "@rollup/plugin-json";
+import copy from "rollup-plugin-copy";
 
 export default {
   input: "src/main.ts",
   output: {
     file: "dist/bundle.js",
     format: "esm",
+    sourcemap: false,
   },
   plugins: [
     json(),
@@ -16,14 +18,21 @@ export default {
     typescript({
       tsconfig: "./tsconfig.json",
     }),
+    copy({
+      targets: [{ src: "locales", dest: "dist" }],
+      copyOnce: false,
+    }),
   ],
   external: [
     "path",
     "fs",
     "os",
-    "tty",
-    "readline",
-    "commander",
+    "chalk",
+    "yargs",
+    "ora",
     "@inquirer/prompts",
+    "commander",
+    "child_process",
+    "module",
   ],
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,27 +1,22 @@
 {
   "compilerOptions": {
-    // Environment setup & latest features
     "lib": ["ESNext"],
     "target": "ESNext",
     "module": "Preserve",
     "moduleDetection": "force",
-    "jsx": "react-jsx",
     "allowJs": true,
 
-    // Bundler mode
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "noEmit": true,
 
-    // Best practices
     "strict": true,
     "skipLibCheck": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
 
-    // Some stricter flags (disabled by default)
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false


### PR DESCRIPTION
## Description

The recent changes focused on resolving the issue where the published package could not find its translation files, as well as fixing subsequent errors that arose.

* **Fixed Locale Asset Bundling:** Resolved the `Failed to load translations` error by adding the `rollup-plugin-copy` to the Rollup configuration. This ensures the `src/locales` directory and its `en.json` file are correctly copied to the `dist` directory during the build process, making them available in the published package.

* **Refined Rollup Configuration:** Removed the `terser` and `preserve-shebangs` plugins from the `rollup.config.js` file, as they were not required for this project, leading to a cleaner and faster build.

* **Resolved TypeScript Error:** Fixed a new `Cannot find type definition file for 'minimatch'` error by installing the corresponding type definitions, `@types/minimatch`, as a development dependency.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] New and existing feature support current supported languages
- [ ] Any dependent changes have been merged and published in downstream modules
