### PR TITLE
feat: add support for the offline auto-completion configuration

### DIFF
--- a/.changeset/tender-poems-exist.md
+++ b/.changeset/tender-poems-exist.md
@@ -1,0 +1,5 @@
+---
+"scaffolder-toolkit": patch
+---
+
+Add support for the offline autocompletion configuration

--- a/packages/devkit/README.md
+++ b/packages/devkit/README.md
@@ -354,7 +354,7 @@ dk init --global
 
 ### Add the JSON Schema for Autocompletion
 
-To get autocompletion and validation for your `.devkit.json` or `.devkitrc` file, you have two options.
+To get autocompletion and validation for your `.devkit.json` or `.devkitrc` file, you have a couple of options.
 
 #### Option 1: Direct Link in the JSON File
 
@@ -399,6 +399,52 @@ For VS Code, open your **`settings.json`** file and add the following entry:
     {
       "fileMatch": [".devkit.json", ".devkitrc"],
       "url": "https://gist.githubusercontent.com/IT-WIBRC/baab4cc74a28af5b23936f5cf576f8e6/raw/ed7445f123554cf5ed7fc6fb727d1faae22a9bed/devkit-schema.json"
+    }
+  ]
+}
+```
+
+Or using the one from `node_modules`(recommended if you have it installed):
+
+```json
+{
+  "json.schemas": [
+    {
+      "fileMatch": [".devkit.json", ".devkitrc"],
+      "url": "node_modules/scaffolder-toolkit/devkit-schema.json"
+    }
+  ]
+}
+```
+
+#### Option 3: Offline Schema
+
+If you prefer to have the schema available offline, you can download the JSON file and link to it locally. This ensures autocompletion and validation work even without an internet connection.
+
+1.  **Download the schema:** Save the file from the URL provided above (`devkit-schema.json`) to a permanent location on your computer.
+2.  **Update your IDE settings:** In your `settings.json`, replace the `url` with a local file path.
+
+Example for macOS/Linux:
+
+```json
+{
+  "json.schemas": [
+    {
+      "fileMatch": [".devkit.json", ".devkitrc"],
+      "url": "/Users/your-username/my-schemas/devkit-schema.json"
+    }
+  ]
+}
+```
+
+Example for Windows:
+
+```json
+{
+  "json.schemas": [
+    {
+      "fileMatch": [".devkit.json", ".devkitrc"],
+      "url": "C:\\Users\\your-username\\my-schemas\\devkit-schema.json"
     }
   ]
 }

--- a/packages/devkit/TODO.md
+++ b/packages/devkit/TODO.md
@@ -27,6 +27,7 @@ This document tracks all planned and completed tasks for the Dev Kit project.
 - [x] Make `config init` default to a local configuration if no flag is passed.
 - [x] Enable monorepo support by correctly identifying the local configuration file.
 - [x] Add the verbose option for detailed output
+- [x] Add support for the offline autocompletion configuration
 
 ---
 

--- a/packages/devkit/__tests__/integrations/common.ts
+++ b/packages/devkit/__tests__/integrations/common.ts
@@ -2,6 +2,8 @@ import path from "path";
 import fileSystem from "../../src/utils/fileSystem.js";
 
 export * from "../../src/utils/configs/schema.js";
+import { SCHEMA_PATH } from "../../src/utils/configs/writer.js";
 
 export const CLI_PATH = path.resolve("./dist/bundle.js");
 export const fs = fileSystem;
+export { SCHEMA_PATH };

--- a/packages/devkit/__tests__/integrations/init.spec.ts
+++ b/packages/devkit/__tests__/integrations/init.spec.ts
@@ -14,11 +14,16 @@ import {
   CLI_PATH,
   fs,
   CONFIG_FILE_NAMES,
-  defaultCliConfig,
+  defaultCliConfig as schemaDefaultCliConfig,
   type CliConfig,
+  SCHEMA_PATH,
 } from "./common.js";
 
 const LOCAL_CONFIG_FILE_NAME = CONFIG_FILE_NAMES[1];
+const defaultCliConfig = {
+  $schema: SCHEMA_PATH,
+  ...schemaDefaultCliConfig,
+};
 
 let tempDir: string;
 let originalCwd: string;

--- a/packages/devkit/__tests__/units/utils/configs/writer.spec.ts
+++ b/packages/devkit/__tests__/units/utils/configs/writer.spec.ts
@@ -3,6 +3,7 @@ import {
   saveConfig,
   saveCliConfig,
   updateTemplateCacheStrategy,
+  SCHEMA_PATH,
 } from "../../../../src/utils/configs/writer.js";
 import { getConfigFilepath } from "../../../../src/utils/configs/path-finder.js";
 import { DevkitError, ConfigError } from "../../../../src/utils/errors/base.js";
@@ -42,7 +43,10 @@ describe("Configuration Writer Functions", () => {
     const config = { setting: "value" };
     mockWriteJson.mockResolvedValueOnce(undefined);
     await saveConfig(config as any, filePath);
-    expect(mockWriteJson).toHaveBeenCalledWith(filePath, config);
+    expect(mockWriteJson).toHaveBeenCalledWith(filePath, {
+      $schema: SCHEMA_PATH,
+      ...config,
+    });
   });
 
   it("saveConfig should throw a DevkitError on write failure", async () => {

--- a/packages/devkit/src/utils/configs/writer.ts
+++ b/packages/devkit/src/utils/configs/writer.ts
@@ -4,9 +4,15 @@ import { t } from "#utils/internationalization/i18n.js";
 import { getConfigFilepath } from "./path-finder.js";
 import { type CliConfig, type CacheStrategy } from "./schema.js";
 
+export const SCHEMA_PATH =
+  "./node_modules/scaffolder-toolkit/devkit-schema.json";
+
 export async function saveConfig(config: CliConfig, filePath: string) {
   try {
-    await fs.writeJson(filePath, config);
+    await fs.writeJson(filePath, {
+      $schema: SCHEMA_PATH,
+      ...config,
+    });
   } catch (error) {
     throw new DevkitError(t("error.config.save", { file: filePath }), {
       cause: error,


### PR DESCRIPTION
## Description

Additionally, this change modifies the `init` command to automatically include a local `$schema` path in the newly created configuration file (`.devkit.json`). This enables offline autocompletion and validation for users, improving the developer experience. The path points to the JSON schema file located within the `node_modules` directory, making the feature self-contained and version-locked to the installed package.

The `README.md` and both unit and integration tests have been updated to reflect these new features.

Fixes # (issue number here if applicable)

---

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

---

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] New and existing feature support current supported languages
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My changes to the configuration are reflected in the JSON schema and the `init` command.
- [x] The `README.md` has been updated with information about the offline schema and the `--verbose` flag.