### PR TITLE
fix: manage config initialization on multi repository

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,3 +1,4 @@
 {
-  "*.{json,md,yml,yaml,cjs}": "prettier --write"
+  "*.{json,md,yml,yaml,cjs}": ["prettier --write"],
+  "packages/**/*.{js,ts}": ["prettier --write", "oxlint --fix"]
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/IT-WIBRC/dev-tools/issues"
   },
   "scripts": {
-    "prepare": "husky",
+    "postinstall": "husky || true",
     "build": "bun --filter '*' build",
     "type-check": "bun --filter '*' type-check",
     "test": "bun --filter '*' test:coverage",
@@ -32,7 +32,8 @@
     "lint": "oxlint --fix .",
     "release": "changeset publish",
     "version": "changeset version",
-    "changeset": "changeset"
+    "changeset": "changeset",
+    "lint-staged": "lint-staged"
   },
   "workspaces": [
     "packages/*"

--- a/packages/devkit/.lintstagedrc.json
+++ b/packages/devkit/.lintstagedrc.json
@@ -1,4 +1,0 @@
-{
-  "*.{ts,js}": ["prettier --write", "oxlint"],
-  "*.{json,md}": "prettier --write"
-}

--- a/packages/devkit/__tests__/integrations/new.spec.ts
+++ b/packages/devkit/__tests__/integrations/new.spec.ts
@@ -153,7 +153,7 @@ describe("dk new", () => {
           path.join(mockProjectDir, "my-vue-app", "vue-test.txt"),
         ),
       ).toBe(true);
-    }, 10000);
+    });
   });
 
   describe("dk new (Monorepo Usage)", () => {

--- a/packages/devkit/__tests__/units/commands/init.spec.ts
+++ b/packages/devkit/__tests__/units/commands/init.spec.ts
@@ -6,6 +6,8 @@ import {
 } from "../../../src/utils/configs/schema.js";
 import { mockSpinner } from "../../../vitest.setup.js";
 import { ConfigError } from "../../../src/utils/errors/base.js";
+import path from "path";
+import os from "os";
 
 const {
   mockFs,
@@ -16,6 +18,7 @@ const {
   mockFindMonorepoRoot,
   mockFindProjectRoot,
   mockFindGlobalConfigFile,
+  mockGetPackageManager,
 } = vi.hoisted(() => ({
   mockFs: {
     pathExists: vi.fn(),
@@ -27,13 +30,21 @@ const {
   mockFindMonorepoRoot: vi.fn(),
   mockFindProjectRoot: vi.fn(),
   mockFindGlobalConfigFile: vi.fn(),
+  mockGetPackageManager: vi.fn(),
 }));
 
 let actionFn: any;
-
-vi.mock("os", () => ({
-  default: {
+vi.mock("os", async () => {
+  const actual = await vi.importActual("os");
+  return {
+    ...actual,
     homedir: vi.fn(() => "/home/user"),
+  };
+});
+
+vi.mock("process", () => ({
+  default: {
+    cwd: vi.fn(() => "/current/directory"),
   },
 }));
 
@@ -41,6 +52,10 @@ vi.mock("#utils/fileSystem.js", () => ({
   default: {
     pathExists: mockFs.pathExists,
   },
+}));
+
+vi.mock("#utils/files/package-manager.js", () => ({
+  getPackageManager: mockGetPackageManager,
 }));
 
 vi.mock("@inquirer/prompts", () => ({ select: mockInquirerSelect }));
@@ -73,9 +88,14 @@ describe("setupInitCommand", () => {
   const localConfigPath = `/current/directory/${localConfigFile}`;
   const globalConfigPath = `/home/user/${globalConfigFile}`;
   const monorepoRootPath = "/monorepo/root";
-  const monorepoRootConfigPath = `${monorepoRootPath}/${localConfigFile}`;
+  const monorepoRootConfigPath = path.join(monorepoRootPath, localConfigFile);
   const projectRootPath = "/project/root";
-  const projectRootConfigPath = `${projectRootPath}/${localConfigFile}`;
+  const projectRootConfigPath = path.join(projectRootPath, localConfigFile);
+
+  const mockDetectedConfig = {
+    ...defaultCliConfig,
+    settings: { ...defaultCliConfig.settings, defaultPackageManager: "npm" },
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -91,6 +111,8 @@ describe("setupInitCommand", () => {
       }),
     };
     vi.spyOn(process, "cwd").mockReturnValue("/current/directory");
+    vi.spyOn(os, "homedir").mockReturnValue("/home/user");
+    mockGetPackageManager.mockResolvedValue("npm");
   });
 
   it("should set up the init command correctly", () => {
@@ -119,8 +141,9 @@ describe("setupInitCommand", () => {
       expect(mockFindGlobalConfigFile).toHaveBeenCalledOnce();
       expect(mockFs.pathExists).toHaveBeenCalledOnce();
       expect(mockFs.pathExists).toHaveBeenCalledWith(globalConfigPath);
+      expect(mockGetPackageManager).toHaveBeenCalledOnce();
       expect(mockSaveConfig).toHaveBeenCalledWith(
-        defaultCliConfig,
+        mockDetectedConfig,
         globalConfigPath,
       );
       expect(mockSpinner.succeed).toHaveBeenCalledWith("config.init.success");
@@ -135,8 +158,9 @@ describe("setupInitCommand", () => {
       expect(mockFindGlobalConfigFile).toHaveBeenCalledOnce();
       expect(mockFs.pathExists).toHaveBeenCalledOnce();
       expect(mockFs.pathExists).toHaveBeenCalledWith(globalConfigPath);
+      expect(mockGetPackageManager).toHaveBeenCalledOnce();
       expect(mockSaveConfig).toHaveBeenCalledWith(
-        defaultCliConfig,
+        mockDetectedConfig,
         globalConfigPath,
       );
       expect(mockSpinner.succeed).toHaveBeenCalledWith("config.init.success");
@@ -159,8 +183,9 @@ describe("setupInitCommand", () => {
         ],
         default: true,
       });
+      expect(mockGetPackageManager).toHaveBeenCalledOnce();
       expect(mockSaveConfig).toHaveBeenCalledWith(
-        defaultCliConfig,
+        mockDetectedConfig,
         globalConfigPath,
       );
       expect(mockSpinner.succeed).toHaveBeenCalledWith("config.init.success");
@@ -175,6 +200,7 @@ describe("setupInitCommand", () => {
       await actionFn({ local: false, global: true });
 
       expect(mockFs.pathExists).toHaveBeenCalledWith(globalConfigPath);
+      expect(mockGetPackageManager).not.toHaveBeenCalled();
       expect(mockSaveConfig).not.toHaveBeenCalled();
       expect(mockSpinner.info).toHaveBeenCalledWith("config.init.aborted");
     });
@@ -184,7 +210,7 @@ describe("setupInitCommand", () => {
     it("should create a local config file in a non-monorepo project when no local config exists", async () => {
       mockFindMonorepoRoot.mockResolvedValueOnce(null);
       mockFindProjectRoot.mockResolvedValueOnce(null);
-      mockFindUp.mockResolvedValue(null);
+      mockFindUp.mockResolvedValueOnce(null);
 
       setupInitCommand({ program: mockProgram });
       await actionFn({ local: true, global: false });
@@ -196,8 +222,9 @@ describe("setupInitCommand", () => {
         cwd: "/current/directory",
         limit: "/current/directory",
       });
+      expect(mockGetPackageManager).toHaveBeenCalledOnce();
       expect(mockSaveConfig).toHaveBeenCalledWith(
-        defaultCliConfig,
+        mockDetectedConfig,
         localConfigPath,
       );
       expect(mockSpinner.succeed).toHaveBeenCalledWith("config.init.success");
@@ -227,8 +254,9 @@ describe("setupInitCommand", () => {
         ],
         default: true,
       });
+      expect(mockGetPackageManager).toHaveBeenCalledOnce();
       expect(mockSaveConfig).toHaveBeenCalledWith(
-        defaultCliConfig,
+        mockDetectedConfig,
         localConfigPath,
       );
       expect(mockSpinner.succeed).toHaveBeenCalledWith("config.init.success");
@@ -258,8 +286,9 @@ describe("setupInitCommand", () => {
         ],
         default: true,
       });
+      expect(mockGetPackageManager).toHaveBeenCalledOnce();
       expect(mockSaveConfig).toHaveBeenCalledWith(
-        defaultCliConfig,
+        mockDetectedConfig,
         monorepoRootConfigPath,
       );
       expect(mockSpinner.succeed).toHaveBeenCalledWith("config.init.success");
@@ -289,8 +318,9 @@ describe("setupInitCommand", () => {
         ],
         default: true,
       });
+      expect(mockGetPackageManager).toHaveBeenCalledOnce();
       expect(mockSaveConfig).toHaveBeenCalledWith(
-        defaultCliConfig,
+        mockDetectedConfig,
         projectRootConfigPath,
       );
       expect(mockSpinner.succeed).toHaveBeenCalledWith("config.init.success");
@@ -305,5 +335,6 @@ describe("setupInitCommand", () => {
       mockSpinner,
     );
     expect(mockSaveConfig).not.toHaveBeenCalled();
+    expect(mockGetPackageManager).not.toHaveBeenCalled();
   });
 });

--- a/packages/devkit/__tests__/units/utils/files/finder.spec.ts
+++ b/packages/devkit/__tests__/units/utils/files/finder.spec.ts
@@ -1,3 +1,4 @@
+// oxlint-disable no-unused-vars
 import { vi, describe, it, expect, beforeEach } from "vitest";
 import {
   findMonorepoRoot,
@@ -23,7 +24,7 @@ const { mockFsStat, mockFsReadJson, mockFindUpLogic } = vi.hoisted(() => {
           if (stats.isFile() || stats.isDirectory()) {
             return filePath;
           }
-        } catch (e) {
+        } catch (_) {
           // File not found, continue search
         }
       }
@@ -51,7 +52,7 @@ vi.mock("#utils/fileSystem.js", () => ({
       try {
         await mockFsStat(p);
         return true;
-      } catch (e) {
+      } catch (_) {
         return false;
       }
     }),

--- a/packages/devkit/__tests__/units/utils/package-manager.spec.ts
+++ b/packages/devkit/__tests__/units/utils/package-manager.spec.ts
@@ -1,0 +1,169 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import {
+  getPackageManager,
+  clearPackageManagerCache,
+} from "../../../src/utils/files/package-manager.js";
+
+const { mockFindUp, mockBunSpawnSync } = vi.hoisted(() => ({
+  mockFindUp: vi.fn(),
+  mockBunSpawnSync: vi.fn(),
+}));
+
+vi.mock("#utils/files/find-up.js", () => ({
+  findUp: mockFindUp,
+}));
+
+vi.mock("path", () => ({
+  default: {
+    resolve: vi.fn((p) => p),
+    join: vi.fn((...args) => args.join("/")),
+    dirname: vi.fn((p) => p.split("/").slice(0, -1).join("/")),
+  },
+}));
+
+vi.mock("node:child_process", () => ({
+  spawnSync: mockBunSpawnSync,
+}));
+
+describe("getPackageManager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearPackageManagerCache();
+    vi.unstubAllGlobals();
+    vi.stubGlobal("process", {
+      ...process,
+      env: {},
+    });
+  });
+
+  it("should return the package manager from `npm_config_user_agent` environment variable", async () => {
+    vi.stubGlobal("process", {
+      ...process,
+      env: { npm_config_user_agent: "pnpm/8.6.0 bun/1.0.0" },
+    });
+
+    const result = await getPackageManager();
+
+    expect(result).toBe("pnpm");
+    expect(mockFindUp).not.toHaveBeenCalled();
+    expect(mockBunSpawnSync).not.toHaveBeenCalled();
+  });
+
+  it("should return the package manager from `yarn.lock` if no env variable is set", async () => {
+    mockFindUp.mockImplementation(async ({ files }) => {
+      if (files.includes("yarn.lock")) {
+        return "yarn.lock";
+      }
+      return null;
+    });
+
+    const result = await getPackageManager();
+
+    expect(result).toBe("yarn");
+    expect(mockFindUp).toHaveBeenCalledTimes(2);
+    expect(mockBunSpawnSync).not.toHaveBeenCalled();
+  });
+
+  it("should return the package manager from `bun.lockb`", async () => {
+    mockFindUp.mockImplementation(async ({ files }) => {
+      if (files.includes("bun.lockb")) {
+        return "bun.lockb";
+      }
+      return null;
+    });
+
+    const result = await getPackageManager();
+
+    expect(result).toBe("bun");
+  });
+
+  it("should return the package manager from `pnpm-lock.yaml`", async () => {
+    mockFindUp.mockImplementation(async ({ files }) => {
+      if (files.includes("pnpm-lock.yaml")) {
+        return "pnpm-lock.yaml";
+      }
+      return null;
+    });
+
+    const result = await getPackageManager();
+
+    expect(result).toBe("pnpm");
+  });
+
+  it("should return the package manager from `package-lock.json`", async () => {
+    mockFindUp.mockImplementation(async ({ files }) => {
+      if (files.includes("package-lock.json")) {
+        return "package-lock.json";
+      }
+      return null;
+    });
+
+    const result = await getPackageManager();
+
+    expect(result).toBe("npm");
+  });
+
+  it("should fall back to a globally available package manager", async () => {
+    mockFindUp.mockResolvedValue(null);
+    mockBunSpawnSync.mockImplementationOnce((command) => {
+      if (command === "bun") {
+        return { status: 0 };
+      }
+      return { status: 1 };
+    });
+
+    const result = await getPackageManager();
+
+    expect(result).toBe("bun");
+    expect(mockBunSpawnSync).toHaveBeenCalledWith("bun", ["--version"], {
+      encoding: "utf-8",
+      stdio: "pipe",
+    });
+  });
+
+  it("should return null if no package manager is found", async () => {
+    mockFindUp.mockResolvedValue(null);
+    mockBunSpawnSync.mockReturnValue({ status: 1 });
+
+    const result = await getPackageManager();
+
+    expect(result).toBeNull();
+  });
+
+  it("should cache the result on the first call", async () => {
+    vi.stubGlobal("process", {
+      ...process,
+      env: { npm_config_user_agent: "pnpm/8.6.0" },
+    });
+
+    const firstCall = await getPackageManager();
+
+    vi.stubGlobal("process", {
+      ...process,
+      env: { npm_config_user_agent: "yarn/1.22.19" },
+    });
+
+    const secondCall = await getPackageManager();
+
+    expect(firstCall).toBe("pnpm");
+    expect(secondCall).toBe("pnpm");
+  });
+
+  it("should bypass the cache and re-detect if `forceRefresh` is true", async () => {
+    vi.stubGlobal("process", {
+      ...process,
+      env: { npm_config_user_agent: "pnpm/8.6.0" },
+    });
+
+    await getPackageManager();
+
+    vi.stubGlobal("process", {
+      ...process,
+      env: { npm_config_user_agent: "yarn/1.22.19" },
+    });
+
+    const result = await getPackageManager(true);
+
+    expect(result).toBe("yarn");
+  });
+});

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -61,7 +61,8 @@
     "type-check": "tsc --noEmit",
     "test:coverage": "vitest run --coverage",
     "test:unit": "vitest",
-    "prepack": "bun run build && bunx cpx ../../LICENSE . && bunx cpx ../../devkit-schema.json .",
+    "prepack": "bun run build && bunx cpx ../../LICENSE . && bunx cpx ../../devkit-schema.json . && pinst --disable",
+    "postpack": "pinst --enable",
     "preversion": "git fetch && git status -uno | grep -Eq 'Your branch is up to date|Your branch is ahead of'",
     "postversion": "git commit -am 'chore(changeset): release'"
   },

--- a/packages/devkit/src/commands/init.ts
+++ b/packages/devkit/src/commands/init.ts
@@ -1,6 +1,7 @@
 import {
   CONFIG_FILE_NAMES,
   defaultCliConfig,
+  type CliConfig,
   type SetupCommandOptions,
 } from "#utils/configs/schema.js";
 import { t } from "#utils/internationalization/i18n.js";
@@ -16,6 +17,7 @@ import { findMonorepoRoot, findProjectRoot } from "#utils/files/finder.js";
 import { findUp } from "#utils/files/find-up.js";
 import { saveConfig } from "#utils/configs/writer.js";
 import { handleErrorAndExit } from "#utils/errors/handler.js";
+import { getPackageManager } from "#utils/files/package-manager.js";
 
 async function promptForStandardOverwrite(filePath: string): Promise<boolean> {
   const response = await select({
@@ -31,6 +33,19 @@ async function promptForStandardOverwrite(filePath: string): Promise<boolean> {
   return response;
 }
 
+async function getUpdatedConfig(): Promise<CliConfig> {
+  const detectedPackageManager = await getPackageManager(true);
+  return {
+    ...defaultCliConfig,
+    settings: {
+      ...defaultCliConfig.settings,
+      defaultPackageManager:
+        detectedPackageManager ||
+        defaultCliConfig.settings.defaultPackageManager,
+    },
+  };
+}
+
 async function handleGlobalInit(spinner: Ora): Promise<void> {
   let finalPath = await findGlobalConfigFile();
   if (!finalPath) {
@@ -42,10 +57,11 @@ async function handleGlobalInit(spinner: Ora): Promise<void> {
     : true;
 
   if (shouldOverwrite) {
+    const configToSave = await getUpdatedConfig();
     spinner.start(
       chalk.cyan(t("config.init.initializing", { path: finalPath })),
     );
-    await saveConfig({ ...defaultCliConfig }, finalPath);
+    await saveConfig(configToSave, finalPath);
     spinner.succeed(chalk.green(t("config.init.success")));
   } else {
     spinner.info(chalk.yellow(t("config.init.aborted")));
@@ -76,10 +92,11 @@ async function handleLocalInit(spinner: Ora): Promise<void> {
   }
 
   if (shouldOverwrite && finalPath) {
+    const configToSave = await getUpdatedConfig();
     spinner.start(
       chalk.cyan(t("config.init.initializing", { path: finalPath })),
     );
-    await saveConfig({ ...defaultCliConfig }, finalPath);
+    await saveConfig(configToSave, finalPath);
     spinner.succeed(chalk.green(t("config.init.success")));
   } else {
     spinner.info(chalk.yellow(t("config.init.aborted")));

--- a/packages/devkit/src/utils/cache/fs-manager.ts
+++ b/packages/devkit/src/utils/cache/fs-manager.ts
@@ -15,6 +15,7 @@ export async function copyTemplate(
 ) {
   try {
     await fs.copy(sourcePath, destinationPath);
+    // oxlint-disable-next-line no-unused-vars
   } catch (error) {
     throw new Error("Failed to copy template.");
   }

--- a/packages/devkit/src/utils/configs/loader.ts
+++ b/packages/devkit/src/utils/configs/loader.ts
@@ -129,6 +129,7 @@ export async function readAndMergeConfigs(
       finalConfig = deepmerge(finalConfig, foundConfig, {
         arrayMerge: (_, sourceArray) => sourceArray,
       });
+      // oxlint-disable-next-line no-unused-vars
     } catch (e) {
       console.error(
         `Warning: Invalid configuration file found at ${configPath}. Using default settings.`,

--- a/packages/devkit/src/utils/fileSystem.ts
+++ b/packages/devkit/src/utils/fileSystem.ts
@@ -55,6 +55,7 @@ async function pathExists(filePath: string): Promise<boolean> {
   try {
     await fsPromises.access(filePath);
     return true;
+    // oxlint-disable-next-line no-unused-vars
   } catch (error) {
     return false;
   }

--- a/packages/devkit/src/utils/files/find-up.ts
+++ b/packages/devkit/src/utils/files/find-up.ts
@@ -24,6 +24,7 @@ export async function findUp({
         if (stats.isDirectory() || stats.isFile()) {
           return filePath;
         }
+        // oxlint-disable-next-line no-unused-vars
       } catch (e) {
         // File does not exist, continue search
       }

--- a/packages/devkit/src/utils/files/package-manager.ts
+++ b/packages/devkit/src/utils/files/package-manager.ts
@@ -1,0 +1,83 @@
+import {
+  JavascriptPackageManagers,
+  SupportedPackageManager,
+} from "#utils/configs/schema.js";
+import { findUp } from "#utils/files/find-up.js";
+import { spawnSync } from "node:child_process";
+
+const cache = new Map<string, SupportedPackageManager | null>();
+
+async function detectPackageManager(): Promise<SupportedPackageManager | null> {
+  const cwd = process.cwd();
+
+  if (process.env.npm_config_user_agent) {
+    const userAgent = process.env.npm_config_user_agent.split(" ")[0];
+    const packageManager = userAgent.substring(0, userAgent.lastIndexOf("/"));
+
+    if (
+      Object.values(JavascriptPackageManagers).includes(
+        packageManager as SupportedPackageManager,
+      )
+    ) {
+      return packageManager as SupportedPackageManager;
+    }
+  }
+
+  const lockFiles = [
+    { name: "pnpm-lock.yaml", pkg: "pnpm" },
+    { name: "yarn.lock", pkg: "yarn" },
+    { name: "package-lock.json", pkg: "npm" },
+    { name: "bun.lockb", pkg: "bun" },
+  ];
+
+  for (const file of lockFiles) {
+    const foundPath = await findUp({
+      files: [file.name],
+      cwd: cwd,
+      limit: cwd,
+    });
+
+    if (foundPath) {
+      return file.pkg as SupportedPackageManager;
+    }
+  }
+
+  const globalManagers = Object.values(JavascriptPackageManagers);
+  for (const manager of globalManagers) {
+    try {
+      const result = spawnSync(manager, ["--version"], {
+        encoding: "utf-8",
+        stdio: "pipe",
+      });
+
+      if (result.status === 0) {
+        return manager as SupportedPackageManager;
+      }
+      // oxlint-disable-next-line no-unused-vars
+    } catch (e) {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+export async function getPackageManager(
+  forceRefresh = false,
+): Promise<SupportedPackageManager | null> {
+  const cacheKey = "package-manager";
+
+  if (!forceRefresh && cache.has(cacheKey)) {
+    return cache.get(cacheKey)!;
+  }
+
+  const packageManager = await detectPackageManager();
+
+  cache.set(cacheKey, packageManager);
+
+  return packageManager;
+}
+
+export function clearPackageManagerCache(): void {
+  cache.clear();
+}

--- a/packages/devkit/src/utils/internationalization/translation-loader.ts
+++ b/packages/devkit/src/utils/internationalization/translation-loader.ts
@@ -36,6 +36,7 @@ export async function loadTranslations(
     const filePath = path.join(localesDir, `${languageToLoad}.json`);
 
     translations = await fs.readJson(filePath);
+    // oxlint-disable-next-line no-unused-vars
   } catch (error) {
     const localesDir = await findLocalesDir();
     const fallbackPath = path.join(localesDir, "en.json");


### PR DESCRIPTION
## Description

We created a utility function to reliably detect the package manager used in a project, specifically designed for monorepo and single-project environments. This function, `getUsedPackageManager`, works by systematically checking for lock files associated with popular package managers.

The core logic of this utility involves:

1.  **Monorepo Root Detection**: First, it determines if the current working directory is part of a monorepo by searching for common indicator files like `pnpm-workspace.yaml` or `lerna.json`.
2.  **Lock File Search**: It then traverses the directory tree upwards from the current location, searching for lock files in a specific order:
    * `bun.lockb` for Bun
    * `yarn.lock` for Yarn
    * `package-lock.json` for npm
    * `pnpm-lock.yaml` for pnpm
3.  **Prioritized Return**: The function prioritizes the search based on the monorepo root. If a monorepo root is found, it will check for a root-level lock file. If no lock file is found at the root, it defaults to checking for a `package.json` file in the current working directory to determine the project's root.
4.  **Result**: It returns the name of the first package manager whose lock file is found, or `null` if none are detected. This ensures that the correct package manager is identified, even when the command is run from a sub-package.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] New and existing feature support current supported languages
- [ ] Any dependent changes have been merged and published in downstream modules
