### PR TITLE
fix(config): update config command alias from 'cf' to 'conf'

### DIFF
--- a/.changeset/clean-pants-yawn.md
+++ b/.changeset/clean-pants-yawn.md
@@ -1,0 +1,5 @@
+---
+"scaffolder-toolkit": patch
+---
+
+fix(config): Update config command alias from 'cf' to 'conf'

--- a/packages/devkit/README.md
+++ b/packages/devkit/README.md
@@ -322,21 +322,21 @@ dk config cache react always-refresh
 
 For a faster workflow, the following commands have shortcuts:
 
-| Command         | Alias    |
-| :-------------- | :------- |
-| `devkit`        | `dk`     |
-| **`info`**      | **`in`** |
-| `init`          | `i`      |
-| `config`        | `cf`     |
-| `new`           | `n`      |
-| `list`          | `ls`     |
-| `config add`    | `cf a`   |
-| `config remove` | `cf rm`  |
-| `config update` | `cf up`  |
-| `config list`   | `cf ls`  |
-| `cache`         | `c`      |
-| `version`       | `v`      |
-| `help`          | `h`      |
+| Command         | Alias     |
+| :-------------- | :-------- |
+| `devkit`        | `dk`      |
+| **`info`**      | **`in`**  |
+| `init`          | `i`       |
+| `config`        | `conf`    |
+| `new`           | `n`       |
+| `list`          | `ls`      |
+| `config add`    | `conf a`  |
+| `config remove` | `conf rm` |
+| `config update` | `conf up` |
+| `config list`   | `conf ls` |
+| `cache`         | `c`       |
+| `version`       | `v`       |
+| `help`          | `h`       |
 
 ---
 

--- a/packages/devkit/__tests__/integrations/config/index.spec.ts
+++ b/packages/devkit/__tests__/integrations/config/index.spec.ts
@@ -222,7 +222,7 @@ describe("dk config", () => {
   it("should throw an error if no config file is found for setting", async () => {
     const { all, exitCode } = await execa(
       "bun",
-      [CLI_PATH, "config", "--set", "language", "en"],
+      [CLI_PATH, "conf", "--set", "language", "en"],
       { all: true, reject: false },
     );
 

--- a/packages/devkit/__tests__/units/commands/config/index.spec.ts
+++ b/packages/devkit/__tests__/units/commands/config/index.spec.ts
@@ -72,7 +72,7 @@ describe("setupConfigCommand", () => {
     setupConfigCommand(mockProgram);
 
     expect(mockProgram.command).toHaveBeenCalledWith("config [keys...]");
-    expect(mockProgram.alias).toHaveBeenCalledWith("cf");
+    expect(mockProgram.alias).toHaveBeenCalledWith("conf");
     expect(mockProgram.description).toHaveBeenCalledWith(
       mocktFn("config.command.description"),
     );

--- a/packages/devkit/src/commands/config/index.ts
+++ b/packages/devkit/src/commands/config/index.ts
@@ -59,7 +59,7 @@ async function handleConfigAction(
 export function setupConfigCommand(program: Command): void {
   const configCommand = program
     .command("config [keys...]")
-    .alias("cf")
+    .alias("conf")
     .description(t("config.command.description"))
     .option("-g, --global", t("config.update.option.global"), false)
     .option("-s, --set <value...>", t("config.set.option.bulk"), false)


### PR DESCRIPTION
## Description

This PR updates the alias for the **`config`** command from the ambiguous `cf` to the more explicit **`conf`**.

This change only affects the shortcut and requires updating the internal command definition and the documentation (README) to reflect the new alias. No core logic or functionality is altered.

### **Changeset**
* Updated the `config` command alias from `cf` to `conf`.
* Updated all related subcommand aliases (e.g., `cf a` to `conf a`, `cf ls` to `conf ls`).
* Updated the **Shortcuts** table in the README.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing feature support current supported languages
- [ ] Any dependent changes have been merged and published in downstream modules
